### PR TITLE
Modify TextField.icon type definition to allow binding

### DIFF
--- a/packages/cx/src/widgets/form/TextField.d.ts
+++ b/packages/cx/src/widgets/form/TextField.d.ts
@@ -64,7 +64,7 @@ export interface TextFieldProps extends FieldProps {
    validationRegExp?: RegExp,
    
    /** Name of the icon to be put on the left side of the input. */
-   icon?: string,
+   icon?: Cx.StringProp,
 
    /** Set to `true` to monitor and report if input value has changed after the form has been
     automatically filled. */


### PR DESCRIPTION
Hello there! We've been looking for an alternative to ExtJS for a new project and have stumbled upon Cx, which looks like a wonderful product at a first glance. We're currently evaluating Cx with TS. I'm going to send a few PRs with issues I've encountered so far.