### PR TITLE
Override React's JSX IntrinsicAttributes definition

### DIFF
--- a/packages/cx/src/core.d.ts
+++ b/packages/cx/src/core.d.ts
@@ -170,6 +170,15 @@ declare global {
       interface IntrinsicElements {
          cx: any
       }
+
+      interface IntrinsicAttributes {
+         key?: any;
+      }
+
+      interface IntrinsicClassAttributes<T> {
+         key?: any;
+         ref?: any;
+      }
    }
 }
 

--- a/packages/cx/src/widgets/Sandbox.d.ts
+++ b/packages/cx/src/widgets/Sandbox.d.ts
@@ -4,8 +4,7 @@ interface SandboxProps extends Cx.PureContainerProps {
 
     storage: Cx.StringProp,
 
-    /* Cx.StringProp doesn't work for unknown reason */
-    key?: any,
+    key?: Cx.StringProp,
 
     accessKey?: Cx.StringProp,
     


### PR DESCRIPTION
```
<Sandbox key={bind('url')}/>
```

fails with "Type ... is not assignable to type 'IntrinsicAttributes'." further stating that property 'key' has an incompatible type. I've found out that React's JSX type definitions set `JSX.IntrinsicAttributes.key` to type `string | number`. That seems to be why `Cx.StringProp` wasn't working correctly for `SandboxProps.key`.

Redefining the attributes solves this. I'm not sure if it breaks anything; Cx seems not to be using `key` or `ref` attributes in the way React does, right?

Also I'm not sure if this is compatible with preact or inferno, but at first glance neither of them (re)defines the interfaces so I guess they should be fine.