### PR TITLE
Replace :bind with -bind syntax in cx-cli scaffold template

### DIFF
--- a/packages/cx-cli/tpl/app/layout/index.js
+++ b/packages/cx-cli/tpl/app/layout/index.js
@@ -31,17 +31,17 @@ export default (
                 <dl>
                     <dt>App</dt>
                     <dd>
-                        <Link href="~/" url:bind="url">
+                        <Link href="~/" url-bind="url">
                             Home
                         </Link>
                     </dd>
                     <dd>
-                        <Link href="~/dashboard" url:bind="url">
+                        <Link href="~/dashboard" url-bind="url">
                             Dashboard
                         </Link>
                     </dd>
                     <dd>
-                        <Link href="~/about" url:bind="url">
+                        <Link href="~/about" url-bind="url">
                             About
                         </Link>
                     </dd>
@@ -49,7 +49,7 @@ export default (
                 <dl>
                     <dt>Admin</dt>
                     <dd>
-                        <Link href="~/users" url:bind="url" match="prefix">
+                        <Link href="~/users" url-bind="url" match="prefix">
                             Users
                         </Link>
                     </dd>

--- a/packages/cx-cli/tpl/app/routes/dashboard/index.js
+++ b/packages/cx-cli/tpl/app/routes/dashboard/index.js
@@ -41,14 +41,14 @@ export default (
                             >
                                 <Gridlines xAxis={false} />
                                 <Repeater
-                                    records:bind="bars"
+                                    records-bind="bars"
                                     recordName="$point"
                                 >
                                     <Column
                                         width={0.8}
-                                        colorIndex:bind="$point.colorIndex"
-                                        x:bind="$point.day"
-                                        y:bind="$point.value"
+                                        colorIndex-bind="$point.colorIndex"
+                                        x-bind="$point.day"
+                                        y-bind="$point.value"
                                     />
                                 </Repeater>
                             </Chart>
@@ -70,22 +70,22 @@ export default (
                             >
                                 <Gridlines xAxis={false} />
                                 <LineGraph
-                                    data:bind="bars"
+                                    data-bind="bars"
                                     xField="day"
                                     yField="value"
                                     colorIndex={6}
                                     lineStyle="stroke-width: 5px"
                                 />
                                 <Repeater
-                                    records:bind="bars"
+                                    records-bind="bars"
                                     recordName="$point"
                                 >
                                     <Marker
                                         size={10}
                                         class="line-marker"
                                         colorIndex={6}
-                                        x:bind="$point.day"
-                                        y:bind="$point.value"
+                                        x-bind="$point.day"
+                                        y-bind="$point.value"
                                         tooltip={{
                                             text: { tpl: "{$point.value:n;0}" },
                                             placement: "up"

--- a/packages/cx-cli/tpl/app/routes/index.js
+++ b/packages/cx-cli/tpl/app/routes/index.js
@@ -11,18 +11,18 @@ import UserRoutes from "./users";
 export default (
     <cx>
         <Sandbox
-            key:bind="url"
-            storage:bind="pages"
+            key-bind="url"
+            storage-bind="pages"
             outerLayout={AppLayout}
             layout={FirstVisibleChildLayout}
         >
-            <Route route="~/" url:bind="url">
+            <Route route="~/" url-bind="url">
                 <Default />
             </Route>
-            <Route route="~/about" url:bind="url">
+            <Route route="~/about" url-bind="url">
                 <About />
             </Route>
-            <Route route="~/dashboard" url:bind="url">
+            <Route route="~/dashboard" url-bind="url">
                 <Dashboard />
             </Route>
             <UserRoutes />

--- a/packages/cx-cli/tpl/app/routes/users/Editor.js
+++ b/packages/cx-cli/tpl/app/routes/users/Editor.js
@@ -21,7 +21,7 @@ export default (
             <Section
                 mod="card"
                 style="max-width: 300px"
-                title:bind="user.display"
+                title-bind="user.display"
             >
                 <ValidationGroup
                     layout={{
@@ -29,32 +29,32 @@ export default (
                         mod: "stretch",
                         vertical: true
                     }}
-                    invalid:bind="invalid"
+                    invalid-bind="invalid"
                 >
                     <TextField
                         label="Username"
-                        value:bind="user.username"
+                        value-bind="user.username"
                         style="width: 100%"
                         required
                     />
                     <TextField
                         label="Display"
-                        value:bind="user.display"
+                        value-bind="user.display"
                         style="width: 100%"
                         required
                     />
                     <TextField
                         label="Email"
-                        value:bind="user.email"
+                        value-bind="user.email"
                         style="width: 100%"
                     />
-                    <Checkbox value:bind="user.enabled">Enabled</Checkbox>
+                    <Checkbox value-bind="user.enabled">Enabled</Checkbox>
                     <hr />
                     <FlexRow spacing>
                         <Button
                             mod="primary"
                             onClick="onSave"
-                            disabled:bind="invalid"
+                            disabled-bind="invalid"
                         >
                             Save
                         </Button>

--- a/packages/cx-cli/tpl/app/routes/users/List.js
+++ b/packages/cx-cli/tpl/app/routes/users/List.js
@@ -19,11 +19,11 @@ export default (
             <Section mod="card">
                 <FlexRow spacing>
                     <TextField
-                        value:bind="search"
+                        value-bind="search"
                         placeholder="Search..."
                         style="flex: 1 0 0"
                         inputStyle="border-color: transparent; box-shadow: none; font-size: 16px"
-                        icon:expr="{status}=='loading' ? 'loading' : 'search'"
+                        icon-expr="{status}=='loading' ? 'loading' : 'search'"
                         showClear
                     />
                     <LinkButton mod="hollow" href="~/users/new">
@@ -33,15 +33,15 @@ export default (
             </Section>
             <FlexRow spacing wrap style="margin-top: 15px">
                 <Repeater
-                    records:bind="results"
+                    records-bind="results"
                     recordAlias="$user"
                     idField="id"
                 >
-                    <Link href:tpl="~/users/{$user.id}" class="user-card">
+                    <Link href-tpl="~/users/{$user.id}" class="user-card">
                         <Section mod="card" class="user-card-body">
                             <img src="http://placehold.it/50x50" />
-                            <h6 text:bind="$user.display" />
-                            @<span text:bind="$user.username" />
+                            <h6 text-bind="$user.display" />
+                            @<span text-bind="$user.username" />
                         </Section>
                     </Link>
                 </Repeater>

--- a/packages/cx-cli/tpl/app/routes/users/index.js
+++ b/packages/cx-cli/tpl/app/routes/users/index.js
@@ -5,10 +5,10 @@ import Editor from "./Editor";
 
 export default (
     <cx>
-        <Route route="~/users" url:bind="url">
+        <Route route="~/users" url-bind="url">
             <List />
         </Route>
-        <Route route="~/users/:userId" url:bind="url">
+        <Route route="~/users/:userId" url-bind="url">
             <Editor />
         </Route>
     </cx>


### PR DESCRIPTION
I performed a test with `yarn create cx-app` and manual syntax replacement, and the bindings were working correctly (there is already a `"babel-preset-env": "^1.6.1"` devDependency inside `tpl/package.json` file) so it should be safe to merge this to the master and republish the cx-cli npm package.