### PR TITLE
add TreeNode hideArrow property

### DIFF
--- a/docs/content/widgets/configs/TreeNode.js
+++ b/docs/content/widgets/configs/TreeNode.js
@@ -82,5 +82,11 @@ export default {
         description: <cx><Md>
             Set to `true` to hide icons.
         </Md></cx>
+    },
+    hideArrow: {
+        type: 'boolean',
+        description: <cx><Md>
+            A value indicating if arrow should be displayed or not. Can be used to hide arrow for folders with no children.
+        </Md></cx>
     }
 };

--- a/packages/cx/src/widgets/grid/TreeNode.d.ts
+++ b/packages/cx/src/widgets/grid/TreeNode.d.ts
@@ -17,7 +17,8 @@ interface TreeNodeProps extends Cx.WidgetProps {
 
    /** Base CSS class to be applied to the element. Defaults to 'treenode'. */
    baseClass?: string,
-   hideIcon?: boolean
+   hideIcon?: boolean,
+   hideArrow?: boolean
 }
 
 export class TreeNode extends Cx.Widget<TreeNodeProps> {

--- a/packages/cx/src/widgets/grid/TreeNode.js
+++ b/packages/cx/src/widgets/grid/TreeNode.js
@@ -21,7 +21,8 @@ export class TreeNode extends Container {
          icon: undefined,
          leafIcon: undefined,
          openFolderIcon: undefined,
-         folderIcon: undefined
+         folderIcon: undefined,
+         hideArrow: undefined
       }, ...arguments);
    }
 
@@ -67,7 +68,7 @@ export class TreeNode extends Container {
             onClick={e => this.toggle(e, instance)}
             onMouseDown={stopPropagation}
          >
-            { !data.leaf && Icon.render(arrowIcon, { className: CSS.element(baseClass, 'arrow')}) }
+            { !data.leaf && !data.hideArrow && Icon.render(arrowIcon, { className: CSS.element(baseClass, 'arrow')}) }
             {
                !this.hideIcon && Icon.render(icon, {
                   className: CSS.element(baseClass, 'icon')


### PR DESCRIPTION
Add hideArrow property to TreeNode widget to be able to hide arrow if folder node has no children.