### PR TITLE
fix grid drag & drop

### DIFF
--- a/packages/cx/src/widgets/grid/Grid.js
+++ b/packages/cx/src/widgets/grid/Grid.js
@@ -1312,14 +1312,14 @@ class GridComponent extends VDOM.Component {
       let {widget} = this.props.instance;
       if (widget.scrollable)
          return this.dom.scroller;
-      return findScrollableParent(this.el, true);
+      return findScrollableParent(this.dom.table, true);
    }
 
    onGetVScrollParent() {
       let {widget} = this.props.instance;
       if (widget.scrollable)
          return this.dom.scroller;
-      return findScrollableParent(this.el);
+      return findScrollableParent(this.dom.table);
    }
 
    componentWillReceiveProps(props) {
@@ -1955,5 +1955,3 @@ function copyCellWidths(srcTableBody, dstTableBody) {
    }
    return changed;
 }
-
-


### PR DESCRIPTION
fix grid methods for getting scroll parents in case when grid is not marked as scrollable