### PR TITLE
fix margin issue in fixed footer grouping grid

### DIFF
--- a/packages/cx/src/widgets/grid/Grid.js
+++ b/packages/cx/src/widgets/grid/Grid.js
@@ -1425,7 +1425,10 @@ class GridComponent extends VDOM.Component {
             this.dom.table.style.marginBottom = `${ (remaining * headerHeight - footerHeight).toFixed(0) }px`;
          } else {
             this.dom.table.style.marginTop = `${-headerHeight}px`;
-            this.dom.table.style.marginBottom = `${-footerHeight}px`;
+
+            // We need negative bottom margin only if we specify in the grouping that footer should be shown, otherwise this margin will hide the last grid row.
+            if (widget.dataAdapter.groupings && widget.dataAdapter.groupings.some(g => g.showFooter))
+               this.dom.table.style.marginBottom = `${-footerHeight}px`;
          }
 
          this.rowHeight = rowHeight;


### PR DESCRIPTION
When defining grouping configuration for grid we can specify whether we want a footer to be shown:
```
grouping={[
    { showFooter: true },
    {...}
]}
```
If we additionally want (which is a common case) this footer to be fixed, we specify _fixedFooter_ property when defining grid. In this case _Cx_ will render 2 footers, with the footer coming from grouping being hidden with negative margin applied on the table wrapper. 
However, if we omit _showFooter_ flag in the grouping configuration (which should be a valid use-case), negative margin will hide the last row (record) in the grid, as there is no grouping footer that needs to be hidden.

The proposed solution is skipping the code that adds the bottom margin in the case when _showFooter_ is not specified in the grouping config. Another possible solution would be to specify this configuration always when we have fixed footer grouping grid.