### PR TITLE
Lookup field bug

### DIFF
--- a/docs/content/widgets/LookupFields.js
+++ b/docs/content/widgets/LookupFields.js
@@ -26,7 +26,7 @@ class PageController extends Controller {
 
         var regex = new RegExp(q, 'gi');
         return new Promise((resolve) => {
-            setTimeout(() => resolve(this.cityDb.filter(x => x.text.match(regex))), 100);
+            setTimeout(() => resolve(this.cityDb.filter(x => x.text.match(regex))), 300);
         });
     }
 }
@@ -75,7 +75,9 @@ export const LookupFields = <cx>
                         label="Remote Data"
                         records:bind="$page.selectedCities"
                         onQuery="query"
-                        multiple/>
+                        minQueryLength={2}
+                        multiple
+                    />
 
                     <LookupField
                         label="Local Filter"

--- a/docs/content/widgets/LookupFields.js
+++ b/docs/content/widgets/LookupFields.js
@@ -76,9 +76,7 @@ export const LookupFields = <cx>
                         records:bind="$page.selectedCities"
                         onQuery="query"
                         minQueryLength={2}
-                        multiple
-                    />
-
+                        multiple/>
                     <LookupField
                         label="Local Filter"
                         records:bind="$page.selectedCities2"
@@ -153,7 +151,7 @@ export const LookupFields = <cx>
 
                    var regex = new RegExp(q, 'gi');
                    return new Promise((resolve) => {
-                      setTimeout(()=> resolve(this.cityDb.filter(x=>x.text.match(regex))), 100);
+                      setTimeout(()=> resolve(this.cityDb.filter(x=>x.text.match(regex))), 300);
                    });
                 }
              }
@@ -183,6 +181,7 @@ export const LookupFields = <cx>
                         label="Remote Data"
                         records:bind="$page.selectedCities"
                         onQuery="query"
+                        minQueryLength={2}
                         multiple/>
                     <LookupField
                         label="Local Filter"

--- a/packages/cx/src/widgets/form/LookupField.js
+++ b/packages/cx/src/widgets/form/LookupField.js
@@ -826,7 +826,7 @@ class LookupComponent extends VDOM.Component {
          if (fetchAll)
             queryDelay = 0;
 
-         if (!this.state.dropdownOpen && !this.cachedResult) {
+         if (!this.cachedResult) {
             this.setState({
                status: "loading"
             });


### PR DESCRIPTION
The condition `!this.state.dropdownOpen` on line 829 was added to avoid showing `loading...` text on every keystroke, which caused a bug where `loading...` is not displayed at all after typing a query. Consequently LookupField appeared as if not working, with results popping up after a while. The issue was especially noticable on queris that took longer to execute. 
I removed that condition since we would normally use query delay to handle the issue it was meant to fix, and in all other cases when onQuery is fetching remote data, we actually want the loading indicator to show.

I also modified the example to be more realistic (it is common to define `minQueryLength` when not using `fetchAll`).