### PR TITLE
Fix HtmlElement jsx spread bug

### DIFF
--- a/packages/cx/src/widgets/HtmlElement.js
+++ b/packages/cx/src/widgets/HtmlElement.js
@@ -21,8 +21,13 @@ export class HtmlElement extends Container {
    constructor(config) {
       super(config);
 
-      if (isUndefined(this.jsxAttributes) && config)
-         this.jsxAttributes = Object.keys(config).filter(::this.isValidHtmlAttribute);
+      if (config)
+         this.jsxAttributes = isUndefined(this.jsxAttributes)
+            ? Object.keys(config).filter(this.isValidHtmlAttribute)
+            : Array.from(new Set([
+              ...this.jsxAttributes,
+              ...Object.keys(config).filter(this.isValidHtmlAttribute)
+            ]));
    }
 
    declareData() {


### PR DESCRIPTION
There was an edge case where props spreading failed to work on any Cx component that extends `HtmlElement`.
Example below:

```
const TestButton = (props) => (
    <cx>
        <Button mod="hollow" 
            text="test"
            icon="refresh" 
            onClick={() => console.log('onClick')}
            {...props}
        />
    </cx>
)
...

// this works as expected
let exampleProps = {
    text: "Props test"
}
<Button mod="hollow" 
    text="test"
    icon="refresh" 
    onClick={() => console.log('onClick')}
    {...exampleProps}
/>
    
// in this case, spreading props within functional component causes HtmlElement to ignore
// `onClick` handler that is defined as a seperate attribute on `Button`
<TestButton
    mod="primary"
/>
```

The changes made in `HtmlElement` fix this issue.