### PR TITLE
submitOnEnter bug litmus and a possible solution

### DIFF
--- a/litmus/bugs/submitOnEnter.js
+++ b/litmus/bugs/submitOnEnter.js
@@ -1,0 +1,66 @@
+import { LookupField, TextField, Button } from "cx/widgets";
+
+export default (
+    <cx>
+        <form
+            onSubmit={(e, {store}) => {
+                e.preventDefault();
+                //document.activeElement.blur();
+
+                store.set('status', 'onSubmit fired!' + ' ' + Date.now());
+            }}
+            style="display: flex; flex-direction: column;"
+        >
+            <TextField label="Text" value-bind="text" />
+            <div style="display: flex; flex-direction: column;">
+                <LookupField
+                    label="Open dropdown on Enter"
+                    value-bind="val1"
+                    options={[
+                        {
+                            id: 0,
+                            text: "Option 0"
+                        },
+                        {
+                            id: 1,
+                            text: "Option 1"
+                        },
+                        {
+                            id: 2,
+                            text: "Option 2"
+                        },
+                        {
+                            id: 3,
+                            text: "Option 3"
+                        },
+                    ]}
+                    //submitOnEnterKey
+                />
+                <LookupField
+                    label="Submit on Enter"
+                    value-bind="val2"
+                    options={[
+                        {
+                            id: 0,
+                            text: "Option 0"
+                        },
+                        {
+                            id: 1,
+                            text: "Option 1"
+                        },
+                        {
+                            id: 2,
+                            text: "Option 2"
+                        },
+                        {
+                            id: 3,
+                            text: "Option 3"
+                        },
+                    ]}
+                    submitOnEnterKey
+                />
+            </div>
+            <h4 text-bind="status" />
+        </form>
+    </cx>
+)

--- a/litmus/index.js
+++ b/litmus/index.js
@@ -32,7 +32,7 @@ import './index.scss';
 //import Demo from './features/context-menu';
 //import Demo from './features/charts/time-axis/LocalTime';
 
-import Demo from './features/grid/header-tool';
+// import Demo from './features/grid/header-tool';
 //import Demo from './features/grid/GridBuffering';
 //import Demo from './features/grid/RowEditing';
 //import Demo from './features/grid/MultiLine';
@@ -73,6 +73,7 @@ import Demo from './features/grid/header-tool';
 //import Demo from "./features/hooks/complex";
 //import Demo from "./features/hooks/localStorage";
 //import Demo from "./bugs/validation";
+import Demo from "./bugs/submitOnEnter";
 
 
 let store = new Store();
@@ -87,4 +88,3 @@ Debug.enable("app-data");
 History.connect(store, "url")
 
 let stop = startHotAppLoop(module, document.getElementById('app'), store, Demo);
-

--- a/packages/cx/src/widgets/form/LookupField.js
+++ b/packages/cx/src/widgets/form/LookupField.js
@@ -722,17 +722,19 @@ class LookupComponent extends VDOM.Component {
 
          case KeyCode.enter:
             if (this.props.instance.widget.submitOnEnterKey) {
-                let instance = this.props.instance.parent;
-                while (instance) {
-                    if (instance.events && instance.events.onSubmit) {
-                        instance.events.onSubmit(e, instance);
-                        break;
-                    } else {
-                        instance = instance.parent;
-                    }
-                }
-                break;
+               let instance = this.props.instance.parent;
+               while (instance) {
+                  if (instance.events && instance.events.onSubmit) {
+                     instance.events.onSubmit(e, instance);
+                     break;
+                  } else {
+                     instance = instance.parent;
+                  }
+               }
+            } else {
+               this.openDropdown(e);
             }
+            break;
 
          default:
             this.openDropdown(e);

--- a/packages/cx/src/widgets/form/LookupField.js
+++ b/packages/cx/src/widgets/form/LookupField.js
@@ -720,6 +720,20 @@ class LookupComponent extends VDOM.Component {
             e.stopPropagation();
             break;
 
+         case KeyCode.enter:
+            if (this.props.instance.widget.submitOnEnterKey) {
+                let instance = this.props.instance.parent;
+                while (instance) {
+                    if (instance.events && instance.events.onSubmit) {
+                        instance.events.onSubmit(e, instance);
+                        break;
+                    } else {
+                        instance = instance.parent;
+                    }
+                }
+                break;
+            }
+
          default:
             this.openDropdown(e);
             break;
@@ -894,5 +908,3 @@ class LookupComponent extends VDOM.Component {
       tooltipParentWillUnmount(this.props.instance);
    }
 }
-
-


### PR DESCRIPTION
Currently LookupField fires onSubmit only if dropdown contains a search field (input) which has focus and fires the onSubmit event on Enter. 
If we don't show the dropdown, the event is never fired, so there is nothing to propagate. 
One possible solution, as suggested below, is to simply check if one of the parent components contains the onSubmit method and to call it directly. 