### PR TITLE
Fix invokeParentMethod call stack overflow bug - call invokeParentMet…

### DIFF
--- a/litmus/bugs/invokeParentMethod.js
+++ b/litmus/bugs/invokeParentMethod.js
@@ -1,0 +1,23 @@
+import { Controller } from "cx/ui";
+import { Button } from "cx/widgets";
+
+class PageController extends Controller {
+    test(val) {
+        console.log('val', val)
+    }
+}
+
+export default (
+    <cx>
+        <div controller={PageController}>
+            <Button
+                onClick={(e, instance) => {
+                    let controller = instance.controller;
+                    // controller.invokeParentMethod('test', 1);
+                    controller.invokeMethod('test', 2)
+                }}
+                text="test"
+            />
+        </div>
+    </cx>
+)

--- a/litmus/index.js
+++ b/litmus/index.js
@@ -84,7 +84,8 @@ import "./index.scss";
 //import Demo from "./features/time-list";
 //import Demo from "./features/debounce/NumberField";
 //import Demo from "./features/uploadButton"
-import Demo from "./bugs/GroupCaptionBug";
+// import Demo from "./bugs/GroupCaptionBug";
+import Demo from "./bugs/invokeParentMethod";
 //import Demo from "./bugs/656";
 //import Demo from "./bugs/RestateFirstVisibleChild";
 //import Demo from "./bugs/TooltipDisable";

--- a/packages/cx/src/ui/Controller.js
+++ b/packages/cx/src/ui/Controller.js
@@ -74,7 +74,7 @@ export class Controller extends Component {
 
    invokeParentMethod(methodName, ...args) {
       let parent = this.instance.parent;
-      return this.instance.invokeControllerMethod.apply(parent, [methodName, ...args]);
+      return parent.invokeControllerMethod(methodName, ...args);
    }
 
    invokeMethod(methodName, ...args) {

--- a/packages/cx/src/ui/Controller.js
+++ b/packages/cx/src/ui/Controller.js
@@ -73,6 +73,11 @@ export class Controller extends Component {
    }
 
    invokeParentMethod(methodName, ...args) {
+      let parent = this.instance.parent;
+      return this.instance.invokeControllerMethod.apply(parent, [methodName, ...args]);
+   }
+
+   invokeMethod(methodName, ...args) {
       return this.instance.invokeControllerMethod(methodName, ...args);
    }
 }

--- a/packages/cx/src/ui/Controller.spec.js
+++ b/packages/cx/src/ui/Controller.spec.js
@@ -378,5 +378,38 @@ describe('Controller', () => {
       let tree1 = component.toJSON();
       assert.equal(store.get("y"), 1);
    });
-});
 
+   it('invokeParentMethod is invoked on parent instance', () => {
+
+      let testValid = [];
+
+      const TestController1 = {
+         onInit() {
+            this.test();
+         },
+         test() {
+            testValid.push(1);
+            this.invokeParentMethod('test', 2);
+         }
+      }
+
+      const TestController2 = {
+         test(val) {
+            testValid.push(val)
+         }
+      }
+
+      let store = new Store();
+
+      const component = renderer.create(
+         <Cx store={store} subscribe immediate>
+            <div controller={TestController2}>
+               <div controller={TestController1}/>
+            </div>
+         </Cx>
+      );
+
+      // let tree = component.toJSON();
+      assert.deepStrictEqual(testValid, [1, 2]);
+   });
+});


### PR DESCRIPTION
I've modified the `invokeParentMethod` to be executed on `parent` instance, so now it's possible to use `invokeParentMethod` inside the method with the same name without causing an infinite call stack, e.g.:
```
<div 
    controller={{
        test(val) {
            console.log(val);
        }
    }}
>
    <div 
        controller={{ 
            test() {
                this.invokeParentMethod('test', 5);
            }
        }}
    />
</div>
```
I also added `Controller.invokeMethod` as an alternative to `instance.invokeControllerMethod` in case we don't want to skip the current controller when looking for a method to invoke, since it also has a valid use-case inside `onClick` handlers:
```
<Menu.Item
   icon="fa-edit"
   text="Edit notes"
   onClick={async (e, { store, controller }) => {              
        let changed = await editTransactionDescription(transaction);
        if (!changed) return;
        // this is useful if we are calling a method that could be either on the current controller, or further up the tree
        controller.invokeMethod("loadData");
    }}
/>
```