### PR TITLE
keep focus on input element after dropdown close

### DIFF
--- a/packages/cx/src/widgets/form/Calendar.js
+++ b/packages/cx/src/widgets/form/Calendar.js
@@ -119,17 +119,18 @@ export class Calendar extends Field {
    }
 }
 
-Calendar.prototype.baseClass = "calendar";
-Calendar.prototype.highlightToday = true;
-Calendar.prototype.maxValueErrorText = "Select a date not after {0:d}.";
-Calendar.prototype.maxExclusiveErrorText = "Select a date before {0:d}.";
-Calendar.prototype.minValueErrorText = "Select a date not before {0:d}.";
-Calendar.prototype.minExclusiveErrorText = "Select a date after {0:d}.";
-Calendar.prototype.disabledDaysOfWeekErrorText = "Selected day of week is not allowed.";
-Calendar.prototype.suppressErrorsUntilVisited = false;
-Calendar.prototype.showTodayButton = false;
-Calendar.prototype.todayButtonText = "Today";
-Calendar.prototype.startWithMonday = false;
+   Calendar.prototype.baseClass = "calendar";
+   Calendar.prototype.highlightToday = true;
+   Calendar.prototype.maxValueErrorText = "Select a date not after {0:d}.";
+   Calendar.prototype.maxExclusiveErrorText = "Select a date before {0:d}.";
+   Calendar.prototype.minValueErrorText = "Select a date not before {0:d}.";
+   Calendar.prototype.minExclusiveErrorText = "Select a date after {0:d}.";
+   Calendar.prototype.disabledDaysOfWeekErrorText = "Selected day of week is not allowed.";
+   Calendar.prototype.suppressErrorsUntilVisited = false;
+   Calendar.prototype.showTodayButton = false;
+   Calendar.prototype.todayButtonText = "Today";
+   Calendar.prototype.startWithMonday = false;
+   Calendar.prototype.focusable = true;
 
 Localization.registerPrototype("cx/widgets/Calendar", Calendar);
 
@@ -420,9 +421,15 @@ export class CalendarCmp extends VDOM.Component {
       return (
          <div
             className={data.classNames}
-            tabIndex={data.disabled ? null : data.tabIndex || 0}
+            tabIndex={data.disabled || !data.focusable ? null : data.tabIndex || 0}
             onKeyDown={(e) => this.handleKeyPress(e)}
-            onMouseDown={(e) => e.stopPropagation()}
+            onMouseDown={(e) => {
+               // prevent losing focus from the input field
+               if (!data.focusable) {
+                  e.preventDefault();
+               }
+               e.stopPropagation();
+            }}
             ref={(el) => {
                this.el = el;
             }}

--- a/packages/cx/src/widgets/form/Calendar.js
+++ b/packages/cx/src/widgets/form/Calendar.js
@@ -34,9 +34,17 @@ export class Calendar extends Field {
             minExclusive: undefined,
             maxValue: undefined,
             maxExclusive: undefined,
+            focusable: undefined
          },
          ...arguments
       );
+   }
+
+   init() {
+      if (this.unfocusable)
+         this.focusable = false;
+
+      super.init();
    }
 
    prepareData(context, { data }) {

--- a/packages/cx/src/widgets/form/DateTimeField.js
+++ b/packages/cx/src/widgets/form/DateTimeField.js
@@ -213,6 +213,7 @@ class DateTimeInput extends VDOM.Component {
                partial: widget.partial,
                encoding: widget.encoding,
                disabledDaysOfWeek: widget.disabledDaysOfWeek,
+               focusable: !widget.focusInputFirst
             };
             break;
 

--- a/packages/cx/src/widgets/form/LookupField.js
+++ b/packages/cx/src/widgets/form/LookupField.js
@@ -537,7 +537,7 @@ class LookupComponent extends VDOM.Component {
                   className={CSS.element(baseClass, "tool")}
                   onMouseDown={preventDefault}
                   onClick={(e) => {
-                     this.toggleDropdown(e);
+                     this.toggleDropdown(e, true);
                      e.stopPropagation();
                      e.preventDefault();
                   }}
@@ -630,16 +630,16 @@ class LookupComponent extends VDOM.Component {
 
    onClick(e) {
       //this should run only for touch devices where mouse events are not called
-      if (!isTouchEvent()) return;
       e.preventDefault();
       e.stopPropagation();
-      this.toggleDropdown(e);
+      if (!isTouchEvent()) return;
+      this.toggleDropdown(e, true);
    }
 
    onMouseDown(e) {
       e.preventDefault();
       e.stopPropagation();
-      this.toggleDropdown(e);
+      this.toggleDropdown(e, true);
    }
 
    onItemClick(e, { store }) {
@@ -810,20 +810,20 @@ class LookupComponent extends VDOM.Component {
          });
    }
 
-   toggleDropdown(e) {
+   toggleDropdown(e, keepFocus) {
       if (this.state.dropdownOpen)
-         this.closeDropdown(e);
+         this.closeDropdown(e, keepFocus);
       else
          this.openDropdown(e);
    }
 
-   closeDropdown(e) {
+   closeDropdown(e, keepFocus) {
       if (this.state.dropdownOpen) {
          this.setState(
             {
                dropdownOpen: false
             },
-            () => this.dom.input.focus()
+            () => keepFocus && this.dom.input.focus()
          );
 
          this.props.instance.setState({

--- a/packages/cx/src/widgets/form/LookupField.js
+++ b/packages/cx/src/widgets/form/LookupField.js
@@ -715,8 +715,6 @@ class LookupComponent extends VDOM.Component {
       }
 
       if (widget.closeOnSelect) {
-         e.persist();
-         console.log(e, document.activeElement);
          //Pressing Tab should work it's own thing. Focus will move elsewhere and the dropdown will close.
          if (e.keyCode != KeyCode.tab) {
             if (!isTouchEvent(e)) this.dom.input.focus();
@@ -821,9 +819,12 @@ class LookupComponent extends VDOM.Component {
 
    closeDropdown(e) {
       if (this.state.dropdownOpen) {
-         this.setState({
-            dropdownOpen: false
-         });
+         this.setState(
+            {
+               dropdownOpen: false
+            },
+            () => this.dom.input.focus()
+         );
 
          this.props.instance.setState({
             visited: true,


### PR DESCRIPTION
Seems like the issue wasn't with the onClick event. Menu was getting dismissed because input wouldn't get focus after dropdown closing.