### PR TITLE
open lookup on focus if autoOpen flag is set

### DIFF
--- a/packages/cx/src/widgets/form/LookupField.js
+++ b/packages/cx/src/widgets/form/LookupField.js
@@ -799,6 +799,9 @@ class LookupComponent extends VDOM.Component {
             focus: true,
          });
       }
+
+      if (this.props.instance.data.autoOpen)
+         this.openDropdown(null);
    }
 
    onBlur(e) {
@@ -937,7 +940,6 @@ class LookupComponent extends VDOM.Component {
    componentDidMount() {
       tooltipParentDidMount(this.dom.input, ...getFieldTooltip(this.props.instance));
       autoFocus(this.dom.input, this);
-      if (this.props.instance.data.autoOpen) this.openDropdown(null);
    }
 
    componentDidUpdate() {


### PR DESCRIPTION
I've removed the logic from the componentDidMount method, not sure if it's correct but it seemed redundant.