### PR TITLE
Column Reordering Example fix

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "casual": "^1.6.2",
     "core-js": "^3.9.1",
-    "cx": "^21.5.0",
+    "cx": "^21.6.0",
     "cx-react": "^17.10.0",
     "illuminate-js": "^0.3.0",
     "intl": "^1.2.5",

--- a/packages/cx/src/widgets/drag-drop/ops.js
+++ b/packages/cx/src/widgets/drag-drop/ops.js
@@ -137,23 +137,23 @@ function notifyDragMove(e, captureData) {
       try {
          let test = zone.onDropTest && zone.onDropTest(event);
          if (!test) return;
+
+         if (zone.onDragMeasure) {
+            let result = zone.onDragMeasure(event, { test }) || {};
+   
+            if (result.near) near.push(zone);
+            else away.push(zone);
+   
+            if (isNumber(result.over) && (best == null || result.over < best)) {
+               over = zone;
+               overTest = test;
+               best = result.over;
+            }
+         }
       }
       catch (err) {
          //the problem is already reported, so here we just swallow the bug to avoid spammming the console too much
          return;
-      }
-
-      if (zone.onDragMeasure) {
-         let result = zone.onDragMeasure(event, { test }) || {};
-
-         if (result.near) near.push(zone);
-         else away.push(zone);
-
-         if (isNumber(result.over) && (best == null || result.over < best)) {
-            over = zone;
-            overTest = test;
-            best = result.over;
-         }
       }
    });
 


### PR DESCRIPTION
Column Reordering has a problem in the documnetation example. After updating to the latest version, I was still getting an error. This fixed the issue for me. 