### PR TITLE
Field.js: Improve async onValidate behavior

### DIFF
--- a/litmus/bugs/AsyncValidator.js
+++ b/litmus/bugs/AsyncValidator.js
@@ -2,59 +2,59 @@ import { LabelsTopLayout, Repeater, Rescope } from 'cx/ui';
 import { Button, HtmlElement, Sandbox, Switch, TextField, ValidationGroup } from 'cx/widgets';
 
 let validate1 = () => Math.random();
-let validate2 = () =>
-  new Promise(resolve => setTimeout(() => resolve(Math.random()), 300));
+let validate2 = (value, instance, params) =>
+   new Promise(resolve => setTimeout(() => resolve(`${Math.random()} ${value} ${JSON.stringify(params)}`), 300));
 
 export default (
-  <cx>
-    <div style="padding: 10px">
-    <ValidationGroup
-      valid-bind="valid1"
-      errors-bind="errors1"
-      layout={LabelsTopLayout}
-    >
-      <TextField
-        label="Sync"
-        validationParams={{ check: { bind: "check1" } }}
-        value-bind="test1"
-        onValidate={validate1}
-      />
-    </ValidationGroup>
+   <cx>
+      <div style="padding: 10px">
+         <ValidationGroup
+            valid-bind="valid1"
+            errors-bind="errors1"
+            layout={LabelsTopLayout}
+         >
+            <TextField
+               label="Sync"
+               validationParams={{ check: { bind: "check1" } }}
+               value-bind="test1"
+               onValidate={validate1}
+            />
+         </ValidationGroup>
 
-    <Switch value-bind="check1">Hit me</Switch>
-    <br />
-    <Button text="Clear" onClick={(e, { store }) => store.delete("test1")} />
-    <ul style="color: red">
-      <Repeater records-bind="errors1">
-        <li text-tpl="{$record.message}" />
-      </Repeater>
-    </ul>
-    <br />
-    <br />
+         <Switch value-bind="check1">Hit me</Switch>
+         <br />
+         <Button text="Clear" onClick={(e, { store }) => store.delete("test1")} />
+         <ul style="color: red">
+            <Repeater records-bind="errors1">
+               <li text-tpl="{$record.message}" />
+            </Repeater>
+         </ul>
+         <br />
+         <br />
 
-    <ValidationGroup
-      valid-bind="valid2"
-      errors-bind="errors2"
-      layout={LabelsTopLayout}
-    >
-      <TextField
-        label="Async"
-        validationParams={{ check: { bind: "check2" } }}
-        value-bind="test2"
-        onValidate={validate2}
-      />
-    </ValidationGroup>
-    <Switch value-bind="check2">Hit me</Switch>
-    <br />
-    <Button text="Clear" onClick={(e, { store }) => store.delete("test2")} />
-    <ul style="color: red">
-      <Repeater records-bind="errors2">
-        <li text-tpl="{$record.message}" />
-      </Repeater>
-    </ul>
-    <br />
-    <br />
+         <ValidationGroup
+            valid-bind="valid2"
+            errors-bind="errors2"
+            layout={LabelsTopLayout}
+         >
+            <TextField
+               label="Async"
+               validationParams={{ check: { bind: "check2" } }}
+               value-bind="test2"
+               onValidate={validate2}
+            />
+         </ValidationGroup>
+         <Switch value-bind="check2">Hit me</Switch>
+         <br />
+         <Button text="Clear" onClick={(e, { store }) => store.delete("test2")} />
+         <ul style="color: red">
+            <Repeater records-bind="errors2">
+               <li text-tpl="{$record.message}" />
+            </Repeater>
+         </ul>
+         <br />
+         <br />
 
-    </div>
-  </cx>
+      </div>
+   </cx>
 );

--- a/litmus/bugs/AsyncValidator.js
+++ b/litmus/bugs/AsyncValidator.js
@@ -1,0 +1,60 @@
+import { LabelsTopLayout, Repeater, Rescope } from 'cx/ui';
+import { Button, HtmlElement, Sandbox, Switch, TextField, ValidationGroup } from 'cx/widgets';
+
+let validate1 = () => Math.random();
+let validate2 = () =>
+  new Promise(resolve => setTimeout(() => resolve(Math.random()), 300));
+
+export default (
+  <cx>
+    <div style="padding: 10px">
+    <ValidationGroup
+      valid-bind="valid1"
+      errors-bind="errors1"
+      layout={LabelsTopLayout}
+    >
+      <TextField
+        label="Sync"
+        validationParams={{ check: { bind: "check1" } }}
+        value-bind="test1"
+        onValidate={validate1}
+      />
+    </ValidationGroup>
+
+    <Switch value-bind="check1">Hit me</Switch>
+    <br />
+    <Button text="Clear" onClick={(e, { store }) => store.delete("test1")} />
+    <ul style="color: red">
+      <Repeater records-bind="errors1">
+        <li text-tpl="{$record.message}" />
+      </Repeater>
+    </ul>
+    <br />
+    <br />
+
+    <ValidationGroup
+      valid-bind="valid2"
+      errors-bind="errors2"
+      layout={LabelsTopLayout}
+    >
+      <TextField
+        label="Async"
+        validationParams={{ check: { bind: "check2" } }}
+        value-bind="test2"
+        onValidate={validate2}
+      />
+    </ValidationGroup>
+    <Switch value-bind="check2">Hit me</Switch>
+    <br />
+    <Button text="Clear" onClick={(e, { store }) => store.delete("test2")} />
+    <ul style="color: red">
+      <Repeater records-bind="errors2">
+        <li text-tpl="{$record.message}" />
+      </Repeater>
+    </ul>
+    <br />
+    <br />
+
+    </div>
+  </cx>
+);

--- a/litmus/index.js
+++ b/litmus/index.js
@@ -48,7 +48,7 @@ import "./index.scss";
 //import Demo from './features/layout/MultiColumnLabelsTopLayout';
 
 //import Demo from './features/menu/icons';
-import Demo from "./features/menu/overflow";
+//import Demo from "./features/menu/overflow";
 //import Demo from './features/window/header-buttons';
 //import Demo from './features/window/persist-position';
 
@@ -94,6 +94,8 @@ import Demo from "./features/menu/overflow";
 //import Demo from "./bugs/656";
 //import Demo from "./bugs/RestateFirstVisibleChild";
 //import Demo from "./bugs/TooltipDisable";
+
+import Demo from "./bugs/AsyncValidator";
 
 
 let store = (window.store = new Store());

--- a/packages/cx/src/widgets/form/Field.js
+++ b/packages/cx/src/widgets/form/Field.js
@@ -14,6 +14,7 @@ import { isTouchEvent } from "../../util/isTouchEvent";
 import { tooltipMouseLeave, tooltipMouseMove } from "../overlay/tooltip-ops";
 import { coalesce } from "../../util/coalesce";
 import { isUndefined } from "../../util/isUndefined";
+import { shallowEquals } from "../../util/shallowEquals";
 
 export class Field extends PureContainer {
    declareData() {
@@ -237,19 +238,19 @@ export class Field extends PureContainer {
       let { data, state } = instance;
       state = state || {};
 
+      let empty = this.isEmpty(data);
+
       if (!data.error) {
-         if (state.validating) data.error = this.validatingText;
-         else if (data.required) {
-            let required = this.validateRequired(context, instance);
-            if (required) data.error = state.inputError || required;
-         }
+         if (state.validating && !empty) data.error = this.validatingText;
+         else if (data.required) data.error = this.validateRequired(context, instance);
       }
 
       if (
+         !empty &&
+         !state.validating &&
          !data.error &&
          this.onValidate &&
-         !state.validating &&
-         (!state.previouslyValidated || data.value != state.lastValidatedValue)
+         (!state.previouslyValidated || data.value != state.lastValidatedValue || data.validationParams != state.lastValidationParams)
       ) {
          let result = instance.invoke("onValidate", data.value, instance, data.validationParams);
          if (isPromise(result)) {
@@ -258,12 +259,18 @@ export class Field extends PureContainer {
                validating: true,
                lastValidatedValue: data.value,
                previouslyValidated: true,
+               lastValidationParams: data.validationParams
             });
             result
                .then((r) => {
+                  let { data, state } = instance;
+                  let error = data.value == state.lastValidatedValue && shallowEquals(data.validationParams, state.lastValidationParams)
+                     ? r
+                     : this.validatingText; //parameters changed, this will be revalidated
+
                   instance.setState({
                      validating: false,
-                     inputError: r,
+                     inputError: error,
                   });
                })
                .catch((e) => {
@@ -276,12 +283,12 @@ export class Field extends PureContainer {
                      Console.warn("Unhandled validation exception:", e);
                   }
                });
-         } else if (!this.isEmpty(data)) {
+         } else {
             data.error = result;
          }
       }
 
-      if (!data.error && state.inputError) data.error = state.inputError;
+      if (!data.error && state.inputError && !empty) data.error = state.inputError;
    }
 
    renderLabel(context, instance, key) {
@@ -371,19 +378,19 @@ export class Field extends PureContainer {
    }
 }
 
-   Field.prototype.validationMode = "tooltip";
-   Field.prototype.suppressErrorsUntilVisited = false;
-   Field.prototype.requiredText = "This field is required.";
-   Field.prototype.autoFocus = false;
-   Field.prototype.asterisk = false;
-   Field.prototype.validatingText = "Validation is in progress...";
-   Field.prototype.validationExceptionText = "Something went wrong during input validation. Check log for more details.";
-   Field.prototype.helpSpacer = true;
-   Field.prototype.trackFocus = false; //add cxs-focus on parent element
-   Field.prototype.labelPlacement = false;
-   Field.prototype.helpPlacement = false;
-   Field.prototype.emptyValue = null;
-   Field.prototype.styled = true;
+Field.prototype.validationMode = "tooltip";
+Field.prototype.suppressErrorsUntilVisited = false;
+Field.prototype.requiredText = "This field is required.";
+Field.prototype.autoFocus = false;
+Field.prototype.asterisk = false;
+Field.prototype.validatingText = "Validation is in progress...";
+Field.prototype.validationExceptionText = "Something went wrong during input validation. Check log for more details.";
+Field.prototype.helpSpacer = true;
+Field.prototype.trackFocus = false; //add cxs-focus on parent element
+Field.prototype.labelPlacement = false;
+Field.prototype.helpPlacement = false;
+Field.prototype.emptyValue = null;
+Field.prototype.styled = true;
 
 //These flags are inheritable and should not be set to false
 //Field.prototype.visited = null;

--- a/packages/cx/src/widgets/form/Field.js
+++ b/packages/cx/src/widgets/form/Field.js
@@ -247,7 +247,6 @@ export class Field extends PureContainer {
 
       if (
          !data.error &&
-         !this.isEmpty(data) &&
          this.onValidate &&
          !state.validating &&
          (!state.previouslyValidated || data.value != state.lastValidatedValue)
@@ -277,7 +276,7 @@ export class Field extends PureContainer {
                      Console.warn("Unhandled validation exception:", e);
                   }
                });
-         } else {
+         } else if (!this.isEmpty(data)) {
             data.error = result;
          }
       }


### PR DESCRIPTION
See https://fiddle.cxjs.io/?f=Ngxbn2M6# for details. This tiny PR
would fix issues 2 and 3. It's not clear why it was undesirable to invoke 
`onValidate` when the field is empty in the first place, but I'm sure
there's a good reason for it. So, I left the behavior intact for 
the synchronous validators (which is 99% of the cases), while
giving a chance to the fields with asynchronous validators
to revalidate (and, possibly, clear out stale errors if that is the 
requirement) when cleared.

Issue 1 is not that easy to fix, as `prevouslyValidated` and
`lastValidatedValue` are "cached". I don't see a chance to
clear them easily, since the revalidation in that case should be
triggered by an unrelated store variable change.