### PR TITLE
Update TreeAdapter.js

### DIFF
--- a/packages/cx/src/ui/adapter/TreeAdapter.js
+++ b/packages/cx/src/ui/adapter/TreeAdapter.js
@@ -21,7 +21,7 @@ export class TreeAdapter extends ArrayAdapter {
       let nonLeafs = [], leafs = [];
       nodes.forEach(record => {
          record.key = parentKey + record.key;
-         this.processNode(context, instance, level, record.data.$leaf ? leafs : nonLeafs, record)
+         this.processNode(context, instance, level, record.data[this.leafField] ? leafs : nonLeafs, record)
       });
       result.push(...nonLeafs, ...leafs);
    }

--- a/packages/cx/src/ui/adapter/TreeAdapter.js
+++ b/packages/cx/src/ui/adapter/TreeAdapter.js
@@ -1,10 +1,8 @@
-import {ArrayAdapter} from './ArrayAdapter';
-import {Binding} from '../../data/Binding';
-import {isArray} from '../../util/isArray';
-import {getAccessor} from "../../data/getAccessor";
+import { getAccessor } from "../../data/getAccessor";
+import { isArray } from "../../util/isArray";
+import { ArrayAdapter } from "./ArrayAdapter";
 
 export class TreeAdapter extends ArrayAdapter {
-
    init() {
       super.init();
       this.childrenAccessor = getAccessor({ bind: `${this.recordName}.${this.childrenField}` });
@@ -13,68 +11,66 @@ export class TreeAdapter extends ArrayAdapter {
    mapRecords(context, instance, data, parentStore, recordsAccessor) {
       let nodes = super.mapRecords(context, instance, data, parentStore, recordsAccessor);
       let result = [];
-      this.processList(context, instance, 0, '', nodes, result);
+      this.processList(context, instance, 0, "", nodes, result);
       return result;
    }
 
    processList(context, instance, level, parentKey, nodes, result) {
-      let nonLeafs = [], leafs = [];
-      nodes.forEach(record => {
+      nodes.forEach((record) => {
          record.key = parentKey + record.key;
-         this.processNode(context, instance, level, record.data[this.leafField] ? leafs : nonLeafs, record)
+         this.processNode(context, instance, level, result, record);
       });
-      result.push(...nonLeafs, ...leafs);
    }
 
    processNode(context, instance, level, result, record) {
       result.push(record);
-      let {data, store} = record;
+      let { data, store } = record;
       data.$level = level;
       if (!data[this.leafField]) {
          if (data[this.expandedField]) {
             if (data[this.childrenField]) {
-               let childNodes = super.mapRecords(context, instance, data[this.childrenField], store, this.childrenAccessor);
-               this.processList(context, instance, level + 1, record.key + ':', childNodes, result);
-            }
-            else if (this.load && !data[this.loadedField] && !data[this.loadingField]) {
+               let childNodes = super.mapRecords(
+                  context,
+                  instance,
+                  data[this.childrenField],
+                  store,
+                  this.childrenAccessor
+               );
+               this.processList(context, instance, level + 1, record.key + ":", childNodes, result);
+            } else if (this.load && !data[this.loadedField] && !data[this.loadingField]) {
                store.set(`${this.recordName}.${this.loadingField}`, true);
                let response = this.load(context, instance, data);
                Promise.resolve(response)
-                  .then(children => {
+                  .then((children) => {
                      store.set(`${this.recordName}.${this.childrenField}`, children);
                      store.set(`${this.recordName}.${this.loadedField}`, true);
                      store.set(`${this.recordName}.${this.loadingField}`, false);
                   })
-                  .catch(response => {
+                  .catch((response) => {
                      store.set(`${this.recordName}.${this.loadingField}`, false);
-                     if (this.onLoadError)
-                        this.onLoadError(response);
+                     if (this.onLoadError) this.onLoadError(response);
                   });
             }
-         } else
-            data[this.expandedField] = false;
+         } else data[this.expandedField] = false;
       }
    }
 
    sort(sorters) {
       if (this.foldersFirst) {
-            if (!sorters || !isArray(sorters))
-                  sorters = [];
+         if (!sorters || !isArray(sorters)) sorters = [];
 
-            sorters = [
-                  {field: this.leafField, direction: "ASC"},
-                  ...sorters
-            ];
+         if (this.foldersFirst) {
+            sorters = [{ field: this.leafField, direction: "ASC" }, ...sorters];
+         }
       }
-
       super.sort(sorters);
    }
 }
 
-TreeAdapter.prototype.childrenField = '$children';
-TreeAdapter.prototype.expandedField = '$expanded';
-TreeAdapter.prototype.leafField = '$leaf';
-TreeAdapter.prototype.loadingField = '$loading';
-TreeAdapter.prototype.loadedField = '$loaded';
+TreeAdapter.prototype.childrenField = "$children";
+TreeAdapter.prototype.expandedField = "$expanded";
+TreeAdapter.prototype.leafField = "$leaf";
+TreeAdapter.prototype.loadingField = "$loading";
+TreeAdapter.prototype.loadedField = "$loaded";
 TreeAdapter.prototype.foldersFirst = true;
 TreeAdapter.prototype.isTreeAdapter = true;


### PR DESCRIPTION
Use provided `leafField` property name instead of the hard-coded `$leaf`.

Note that processList method in the TreeAdapter does `result.push(...nonLeafs, ...leafs);` which basically always returns non leaf elements before leaf elements. The sorting logic that we added to TreeAdapter sort method does not have any affect on the order of the elements, as the sorting logic is applied before the processing is done. :)

We should probably consider `foldersFirst` property when processing the results, like it's done in the sort method.

Last, can we use preSorters to achieve this sorting logic, when foldersFirst is set to true.