### PR TITLE
Show fixed footers even if grid is not scrollable

### DIFF
--- a/packages/cx/package.json
+++ b/packages/cx/package.json
@@ -1,6 +1,6 @@
 {
    "name": "cx",
-   "version": "22.3.1",
+   "version": "22.3.4",
    "description": "Advanced JavaScript UI framework for admin and dashboard applications with ready to use grid, form and chart components.",
    "main": "index.js",
    "jsnext:main": "src/index.js",

--- a/packages/cx/src/widgets/grid/Grid.js
+++ b/packages/cx/src/widgets/grid/Grid.js
@@ -1084,13 +1084,14 @@ export class Grid extends Widget {
       //it doesn't make sense to show the footer if the grid is empty though
       let record = records[records.length - 1];
 
-      instance.fixedFooterOverlap = record.type == "group-footer";
+      instance.fixedFooterOverlap = true;
+      instance.fixedFooterIsGroupFooter = record.type == "group-footer";
 
       instance.fixedFooterVDOM = this.renderGroupFooter(
          context,
          instance,
          record.grouping,
-         record.level,
+         record.level || 1,
          record.group || { $key: "fixed-footer" },
          record.key + "-footer",
          record.store,
@@ -1544,7 +1545,7 @@ class GridComponent extends VDOM.Component {
                </tr>
             </tbody>,
          ];
-      } else if (widget.buffered) {
+      } else if (widget.fixedFooter && (widget.buffered || !instance.fixedFooterIsGroupFooter)) {
          //add fixed footer content for buffered grids
          if (fixedFooter || fixedColumnsFixedFooter) {
             children.push(fixedFooter);

--- a/packages/cx/src/widgets/grid/Grid.js
+++ b/packages/cx/src/widgets/grid/Grid.js
@@ -1552,6 +1552,8 @@ class GridComponent extends VDOM.Component {
          }
       }
 
+      let shouldRenderFixedFooter = widget.scrollable && (fixedFooter || fixedColumnsFixedFooter);
+
       if (hasFixedColumns) {
          fixedColumnsContent.push(
             <div
@@ -1559,7 +1561,7 @@ class GridComponent extends VDOM.Component {
                ref={this.fixedScrollerRef}
                className={CSS.element(baseClass, "fixed-scroll-area", {
                   "fixed-header": !!this.props.header,
-                  "fixed-footer": widget.buffered && (fixedFooter || fixedColumnsFixedFooter),
+                  "fixed-footer": shouldRenderFixedFooter,
                })}
             >
                <div className={CSS.element(baseClass, "fixed-table-wrapper")}>
@@ -1583,7 +1585,7 @@ class GridComponent extends VDOM.Component {
             onScroll={this.onScroll.bind(this)}
             className={CSS.element(baseClass, "scroll-area", {
                "fixed-header": !!this.props.header,
-               "fixed-footer": widget.buffered && (fixedFooter || fixedColumnsFixedFooter),
+               "fixed-footer": shouldRenderFixedFooter,
             })}
          >
             <div className={CSS.element(baseClass, "table-wrapper")}>
@@ -1631,7 +1633,7 @@ class GridComponent extends VDOM.Component {
             </div>
          );
 
-      if (fixedFooter || fixedColumnsFixedFooter) {
+      if (shouldRenderFixedFooter) {
          content.push(
             <div
                key="ff"
@@ -1639,9 +1641,6 @@ class GridComponent extends VDOM.Component {
                   this.dom.fixedFooter = el;
                }}
                className={CSS.element(baseClass, "fixed-footer")}
-               style={{
-                  display: this.scrollWidth > 0 ? "block" : "none",
-               }}
             >
                <table>{fixedFooter}</table>
             </div>
@@ -1655,9 +1654,6 @@ class GridComponent extends VDOM.Component {
                      this.dom.fixedColumnsFixedFooter = el;
                   }}
                   className={CSS.element(baseClass, "fixed-fixed-footer")}
-                  style={{
-                     display: this.scrollWidth > 0 ? "block" : "none",
-                  }}
                >
                   <table>{fixedColumnsFixedFooter}</table>
                </div>

--- a/packages/cx/src/widgets/grid/Grid.scss
+++ b/packages/cx/src/widgets/grid/Grid.scss
@@ -589,12 +589,36 @@
       }
    }
 
+   .#{$element}#{$name}-scroll-area {
+      &.#{$state}fixed-footer
+         > .#{$element}#{$name}-table-wrapper
+         > table
+         > .#{$element}#{$name}-group-footer:last-child {
+         visibility: hidden;
+
+         td {
+            border: none;
+         }
+      }
+   }
+
    .#{$element}#{$name}-fixed-scroll-area {
       overflow-x: scroll;
       overflow-y: hidden;
       border-color: $cx-default-grid-border-color;
       border-right-style: solid;
       border-right-width: 1px;
+
+      &.#{$state}fixed-footer
+         > .#{$element}#{$name}-fixed-table-wrapper
+         > table
+         > .#{$element}#{$name}-group-footer:last-child {
+         visibility: hidden;
+
+         td {
+            border: none;
+         }
+      }
    }
 
    .#{$element}#{$name}-col-header-tool {


### PR DESCRIPTION
Render hidden footers for buffered grids for proper column sizing.