### PR TITLE
Fix: Remove z-index form fiddle button

### DIFF
--- a/docs/components/CodeSnippet.scss
+++ b/docs/components/CodeSnippet.scss
@@ -43,7 +43,6 @@
    padding: 4px 10px;
    text-decoration: none;
    color: #fff;
-   z-index: 2000;
    border-radius: 2px;
 
    opacity: 1;


### PR DESCRIPTION
When scrolling, fiddle button would go over navbar. 