### PR TITLE
TS > Missing Props: Content

### DIFF
--- a/packages/cx/src/ui/layout/Content.d.ts
+++ b/packages/cx/src/ui/layout/Content.d.ts
@@ -3,11 +3,8 @@ import * as Cx from '../../core';
 interface ContentProps extends Cx.PureContainerProps {
 
 
-   /** Placeholder name where the content is rendered. Interchangeable with `for` property, but has a lower priority. */
+   /** Placeholder name where the content is rendered. */
    name?: string,
-
-     /** Placeholder name where the content is rendered. Interchangeable with `name` property, but has a higher priority. */
-   for?: string,
 
    isContent?: boolean
 

--- a/packages/cx/src/ui/layout/Content.d.ts
+++ b/packages/cx/src/ui/layout/Content.d.ts
@@ -2,8 +2,13 @@ import * as Cx from '../../core';
 
 interface ContentProps extends Cx.PureContainerProps {
 
+
+   /** Placeholder name where the content is rendered. Interchangeable with `for` property, but has a lower priority. */
    name?: string,
-   putInto?: string,
+
+     /** Placeholder name where the content is rendered. Interchangeable with `name` property, but has a higher priority. */
+   for?: string,
+
    isContent?: boolean
 
 }


### PR DESCRIPTION
Please check if the comments are acceptable. In the `onInit` function, if both `name` and `for` properties are defined, `for` will be used, so I tried to clarify that.