### PR TITLE
Change base class of Link compontnt

### DIFF
--- a/packages/cx/src/widgets/nav/Link.d.ts
+++ b/packages/cx/src/widgets/nav/Link.d.ts
@@ -1,8 +1,9 @@
 import * as React from "react";
 import * as Cx from "../../core";
 import { Instance } from "../../ui/Instance";
+import { LinkButtonProps } from "./LinkButton";
 
-interface LinkProps extends Cx.HtmlElementProps {
+interface LinkProps extends LinkButtonProps {
    /** Set to `true` to disable the link. */
    disabled?: Cx.BooleanProp;
 

--- a/packages/cx/src/widgets/nav/LinkButton.d.ts
+++ b/packages/cx/src/widgets/nav/LinkButton.d.ts
@@ -1,7 +1,7 @@
 import * as Cx from "../../core";
 import { ButtonProps } from "../Button";
 
-interface LinkButtonProps extends ButtonProps {
+export interface LinkButtonProps extends ButtonProps {
    /** Url to the link's target location. Should start with `~/` or `#/` for pushState/hash based navigation. */
    href?: Cx.StringProp;
 


### PR DESCRIPTION
Changing the base class of the Link component. Some properties that are used have the TS definition is missing because there is a wrong base class in TS component.