### PR TITLE
Fix view methods precedence

### DIFF
--- a/packages/cx/src/data/View.d.ts
+++ b/packages/cx/src/data/View.d.ts
@@ -16,6 +16,7 @@ export interface ViewMethods<D = Record> {
    init<V>(path: AccessorChain<V>, value: V): boolean;
 
    set(path: Path, value: any): boolean;
+   set(changes: Record): boolean;
    set<V>(path: AccessorChain<V>, value: V): boolean;
 
    get(path: Path): any;
@@ -58,6 +59,7 @@ export class View<D = any> implements ViewMethods<D> {
    init<V>(path: AccessorChain<V>, value: V): boolean;
 
    set(path: Path, value: any): boolean;
+   set(changes: Record): boolean;
    set<V>(path: AccessorChain<V>, value: V): boolean;
 
    /**

--- a/packages/cx/src/data/View.d.ts
+++ b/packages/cx/src/data/View.d.ts
@@ -16,13 +16,11 @@ export interface ViewMethods<D = Record> {
    init<V>(path: AccessorChain<V>, value: V): boolean;
 
    set(path: Path, value: any): boolean;
-   set(path: Record, value: Record): boolean;
    set<V>(path: AccessorChain<V>, value: V): boolean;
 
    get(path: Path): any;
    get(paths: Path[]): any[];
    get(...paths: Path[]): any[];
-   get<V>(path: AccessorChain<V>): V;
 
    /**
     * Removes data from the Store.
@@ -59,7 +57,6 @@ export class View<D = any> implements ViewMethods<D> {
    init<V>(path: AccessorChain<V>, value: V): boolean;
 
    set(path: Path, value: any): boolean;
-   set(path: Record, value: Record): boolean;
    set<V>(path: AccessorChain<V>, value: V): boolean;
 
    /**

--- a/packages/cx/src/data/View.d.ts
+++ b/packages/cx/src/data/View.d.ts
@@ -21,6 +21,7 @@ export interface ViewMethods<D = Record> {
    get(path: Path): any;
    get(paths: Path[]): any[];
    get(...paths: Path[]): any[];
+   get<V>(path: AccessorChain<V>): V;
 
    /**
     * Removes data from the Store.


### PR DESCRIPTION
The problem was if the `set<V>(path: AccessorChain<V>, value: V)` signature is not matched, the `set(path: Record, value: Record)` will match even if the path is of `AccessorChain` type
I could not find any other solution except removing `set(Record, Record)` 
I do not know the impact of this change.