### PR TITLE
Remove preventDefault from onWheel listner in Slider

### DIFF
--- a/litmus/features/slider/SliderPreventDefault.js
+++ b/litmus/features/slider/SliderPreventDefault.js
@@ -1,0 +1,9 @@
+import { Slider } from "cx/widgets";
+
+export default (
+   <cx>
+      <div style="height: 2000px">
+         <Slider to-bind="test" wheel maxValue={100} step={1} />
+      </div>
+   </cx>
+);

--- a/litmus/features/slider/SliderPreventDefault.js
+++ b/litmus/features/slider/SliderPreventDefault.js
@@ -1,9 +1,20 @@
-import { Slider } from "cx/widgets";
+import { Repeater, Slider } from "cx/widgets";
 
 export default (
    <cx>
-      <div style="height: 2000px">
-         <Slider to-bind="test" wheel maxValue={100} step={1} />
+      <div
+         style="height: 2000px"
+         controller={{
+            onInit() {
+               this.store.set("arr", [{}, {}, {}]);
+            },
+         }}
+      >
+         <Repeater records-bind="arr">
+            <div>
+               <Slider to-bind="$record.value" wheel maxValue={100} step={1} />
+            </div>
+         </Repeater>
       </div>
    </cx>
 );

--- a/litmus/index.js
+++ b/litmus/index.js
@@ -105,7 +105,8 @@ import "./index.scss";
 // import Demo from "./bugs/LookupFieldListItemFocus";
 //import Demo from "./bugs/SliderValue";
 //import Demo from "./features/context-menu/conext-menu-in-a-dropdown";
-import Demo from "./features/calendar";
+// import Demo from "./features/calendar";
+import Demo from "./features/slider/SliderPreventDefault";
 
 let store = (window.store = new Store());
 

--- a/packages/cx/src/widgets/form/Slider.js
+++ b/packages/cx/src/widgets/form/Slider.js
@@ -313,7 +313,7 @@ class SliderComponent extends VDOM.Component {
       let { data, widget } = instance;
       if ((widget.showFrom && widget.showTo) || !data.wheel) return;
 
-      e.preventDefault();
+      // e.preventDefault(); <- wheel is a passive event listener, so preventDefault() is not allowed
       e.stopPropagation();
 
       let increment = e.deltaY > 0 ? this.getIncrement() : -this.getIncrement();

--- a/packages/cx/src/widgets/form/Slider.js
+++ b/packages/cx/src/widgets/form/Slider.js
@@ -312,12 +312,15 @@ class SliderComponent extends VDOM.Component {
    }
 
    subscribeOnWheel(el) {
-      if (this.unsubscribeOnWheel) {
-         this.unsubscribeOnWheel();
-         this.unsubscribeOnWheel = null;
+      // el will be passed as null when the component is unmounted
+      let { instance } = this.props;
+
+      if (instance.unsubscribeOnWheel) {
+         instance.unsubscribeOnWheel();
+         instance.unsubscribeOnWheel = null;
       }
       if (el) {
-         this.unsubscribeOnWheel = addEventListenerWithOptions(el, "wheel", (e) => this.onWheel(e), {
+         instance.unsubscribeOnWheel = addEventListenerWithOptions(el, "wheel", (e) => this.onWheel(e), {
             passive: false,
          });
       }


### PR DESCRIPTION
`Wheel` is a passive event listener, which means that it will never call `preventDefault`, as per [documentation](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener).