### PR TITLE
Update Format.js

### DIFF
--- a/packages/cx/src/ui/Format.js
+++ b/packages/cx/src/ui/Format.js
@@ -65,7 +65,7 @@ export function enableCultureSensitiveFormatting() {
 
    Fmt.registerFactory(['date', 'd'], (fmt, format = 'yyyyMMdd') => {
       let culture = Culture.getDateTimeCulture();
-      let formatter = culture.getFormatter();
+      let formatter = culture.getFormatter(format);
       return value => formatter.format(new Date(value));
    });
 


### PR DESCRIPTION
Pass default format to intl.io getFormatter function to correctly generate default datetime format options