### PR TITLE
allow ctrl+wheel zoom while modals are opened

### DIFF
--- a/packages/cx/src/widgets/overlay/Overlay.js
+++ b/packages/cx/src/widgets/overlay/Overlay.js
@@ -626,7 +626,7 @@ export class OverlayComponent extends VDOM.Component {
             this.shadowEl,
             "wheel",
             (e) => {
-               if (e.shiftKey) return;
+               if (e.shiftKey || e.ctrlKey) return;
                //check if there is a scrollable element within the shadow or overlay contents
                //such that its scrollbar is not at the very end
                let scrollAllowed = false;


### PR DESCRIPTION
This PR is related to bug that is reported on Lorino: [SL-619](https://yt.codaxy.com/issue/SL-619/Feed-Modals-preventing-page-zoom-in)

I was looking at handleKeyDown() in Overlay.js but didn't find anything unusual, then I searched for handling of wheel events.
I just added ctrlKey where check for shiftKey was to allow default behavior of wheel event within shadowEl **while Ctrl is pressed**.
I haven't noticed any unusual behaviour after the addition.