### PR TITLE
support providing/inferring records type for repeater, list and grid

### DIFF
--- a/packages/cx/src/ui/Repeater.d.ts
+++ b/packages/cx/src/ui/Repeater.d.ts
@@ -7,14 +7,13 @@ import {
    CollatorOptions,
    Widget,
    PureContainerProps,
-   Record,
    Prop,
    SortDirection,
 } from "../core";
 import { Instance } from "./Instance";
 
-interface RepeaterProps extends PureContainerProps {
-   records: RecordsProp;
+interface RepeaterProps<T = unknown> extends PureContainerProps {
+   records: Prop<T[]>;
    recordName?: RecordAlias;
    recordAlias?: RecordAlias;
    indexName?: RecordAlias;
@@ -39,14 +38,14 @@ interface RepeaterProps extends PureContainerProps {
    filterParams?: StructuredProp;
 
    /** Callback to create a filter function for given filter params. */
-   onCreateFilter?: (filterParams: any, instance: Instance) => (record: Record) => boolean;
+   onCreateFilter?: (filterParams: any, instance: Instance) => (record: T) => boolean;
 
    /**
     * Callback function to track and retrieve displayed records.
     * Accepts new records as a first argument.
     * If onCreateFilter callback is defined, filtered records can be retrieved using this callback.
     */
-   onTrackMappedRecords?: string | ((records: Record[], instance: Instance) => void);
+   onTrackMappedRecords?: string | ((records: T[], instance: Instance) => void);
 
    /** Options for data sorting. See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Collator */
    sortOptions?: CollatorOptions;
@@ -58,4 +57,4 @@ interface RepeaterProps extends PureContainerProps {
    dataAdapter?: any;
 }
 
-export class Repeater extends Widget<RepeaterProps> {}
+export class Repeater<T> extends Widget<RepeaterProps<T>> {}

--- a/packages/cx/src/ui/Repeater.d.ts
+++ b/packages/cx/src/ui/Repeater.d.ts
@@ -57,4 +57,4 @@ interface RepeaterProps<T = unknown> extends PureContainerProps {
    dataAdapter?: any;
 }
 
-export class Repeater<T> extends Widget<RepeaterProps<T>> {}
+export class Repeater<T = unknown> extends Widget<RepeaterProps<T>> {}

--- a/packages/cx/src/widgets/List.d.ts
+++ b/packages/cx/src/widgets/List.d.ts
@@ -91,4 +91,4 @@ interface ListProps<T = unknown> extends StyledContainerProps {
    keyField?: string;
 }
 
-export class List<T> extends Widget<ListProps<T>> {}
+export class List<T = unknown> extends Widget<ListProps<T>> {}

--- a/packages/cx/src/widgets/List.d.ts
+++ b/packages/cx/src/widgets/List.d.ts
@@ -4,9 +4,8 @@ import {
    ClassProp,
    CollatorOptions,
    Config,
-   Record,
+   Prop,
    RecordAlias,
-   RecordsProp,
    SortersProp,
    StringProp,
    StructuredProp,
@@ -20,9 +19,9 @@ type KeyDownPipe = (event: KeyboardEvent) => void;
 
 type PipeKeyDownCallback = (pipe: KeyDownPipe) => void;
 
-interface ListProps extends StyledContainerProps {
+interface ListProps<T = unknown> extends StyledContainerProps {
    /** An array of records to be displayed in the list. */
-   records?: RecordsProp;
+   records?: Prop<T[]>;
 
    /** Used for sorting the list. */
    sorters?: SortersProp;
@@ -65,7 +64,7 @@ interface ListProps extends StyledContainerProps {
    filterParams?: StructuredProp;
 
    /** Callback to create a filter function for given filter params. */
-   onCreateFilter?: (filterParams: any, instance: Instance) => (record: Record) => boolean;
+   onCreateFilter?: (filterParams: any, instance: Instance) => (record: T) => boolean;
 
    /** Scrolls selection into the view. Default value is false. */
    scrollSelectionIntoView?: boolean;
@@ -92,4 +91,4 @@ interface ListProps extends StyledContainerProps {
    keyField?: string;
 }
 
-export class List extends Widget<ListProps> {}
+export class List<T> extends Widget<ListProps<T>> {}

--- a/packages/cx/src/widgets/grid/Grid.d.ts
+++ b/packages/cx/src/widgets/grid/Grid.d.ts
@@ -400,4 +400,4 @@ interface GridCellEditInfo<T> extends GridCellInfo {
    newData: T;
 }
 
-export class Grid<T> extends Widget<GridProps<T>> {}
+export class Grid<T = unknown> extends Widget<GridProps<T>> {}

--- a/packages/cx/src/widgets/grid/Grid.d.ts
+++ b/packages/cx/src/widgets/grid/Grid.d.ts
@@ -155,9 +155,9 @@ interface GridRowConfig {
    mod?: StringProp | Prop<string[]> | StructuredProp;
 }
 
-interface GridProps extends StyledContainerProps {
+interface GridProps<T = unknown> extends StyledContainerProps {
    /** An array of records to be displayed in the grid. */
-   records?: Prop<Record[]>;
+   records?: Prop<T[]>;
 
    /** Set to true to add a vertical scroll and a fixed header to the grid. */
    scrollable?: boolean;
@@ -298,7 +298,7 @@ interface GridProps extends StyledContainerProps {
    filterParams?: StructuredProp;
 
    /** Callback to create a filter function for given filter params. */
-   onCreateFilter?: (filterParams: any, instance?: Instance) => (record: Record) => boolean;
+   onCreateFilter?: (filterParams: any, instance?: Instance) => (record: T) => boolean;
 
    /** Enable infinite scrolling */
    infinite?: boolean;
@@ -337,7 +337,7 @@ interface GridProps extends StyledContainerProps {
    onBeforeCellEdit?: string | ((change: GridCellBeforeEditInfo, record: DataAdapterRecord) => any);
 
    /** A callback function which is executed after a cell has been successfully edited. */
-   onCellEdited?: string | ((change: GridCellEditInfo, record: DataAdapterRecord) => void);
+   onCellEdited?: string | ((change: GridCellEditInfo<T>, record: DataAdapterRecord) => void);
 
    /** A callback function which is executed after a column has been resized. */
    onColumnResize?: (data: { width: number; column: Record }, instance: Instance) => void;
@@ -349,7 +349,7 @@ interface GridProps extends StyledContainerProps {
    onCreateIsRecordSelectable?: (
       params: any,
       instance: Instance
-   ) => (record: Record, options?: { range?: boolean; toggle?: boolean }) => boolean;
+   ) => (record: T, options?: { range?: boolean; toggle?: boolean }) => boolean;
 
    /** Parameters whose change will cause scroll to be reset. */
    scrollResetParams?: StructuredProp;
@@ -380,10 +380,10 @@ interface GridProps extends StyledContainerProps {
     * Accepts new records as a first argument.
     * If onCreateFilter callback is defined, filtered records can be retrieved using this callback.
     */
-   onTrackMappedRecords?: string | ((records: Record[], instance: Instance) => void);
+   onTrackMappedRecords?: string | ((records: T[], instance: Instance) => void);
 
    /** Callback to create a function that can be used to check whether a record is draggable. */
-   onCreateIsRecordDraggable?: (params: any, instance: Instance) => (record: Record) => boolean;
+   onCreateIsRecordDraggable?: (params: any, instance: Instance) => (record: T) => boolean;
 }
 
 interface GridCellInfo {
@@ -395,9 +395,9 @@ interface GridCellBeforeEditInfo extends GridCellInfo {
    data: any;
 }
 
-interface GridCellEditInfo extends GridCellInfo {
-   oldData: any;
-   newData: any;
+interface GridCellEditInfo<T> extends GridCellInfo {
+   oldData: T;
+   newData: T;
 }
 
-export class Grid extends Widget<GridProps> {}
+export class Grid<T> extends Widget<GridProps<T>> {}


### PR DESCRIPTION
Other types/interfaces to consider within Grid component:
* `MappedGridRecord`: it has a data property of type `Record`, however, I wasn't sure whether it's a record from the Grid records property, or some wrapper around it.
* `GridDragEvent`: `recordBefore` and `recordAfter` are of the `MappedGridRecord` type.
* `GridRowDragEvent`: similar like the previous one, `record` is of type `MappedGridRecord`.
* `GridCellBeforeEditInfo`: has `data` property which somewhat suggests connection with the records.
* `onBeforeCellEdit` and `onCellEdited` callbacks receive `record: DataAdapterRecord` as a second argument. Could this also be a Generic - `DataAdapterRecord<T>`, since this type has a `data` property of type any.