### PR TITLE
Fix cx-cli parsing

### DIFF
--- a/packages/cx-cli/index.js
+++ b/packages/cx-cli/index.js
@@ -16,11 +16,16 @@ program.command("create")
         createNewApp(name);
     });
 
-program.command("add, route")
+program.command("add")
     .description("Add new route folder")
+    .argument('<type>')
     .argument('<name>', 'route folder')
-    .action((routeName) => {
-        addRoute(routeName);
+    .action((type, name) => {
+        if (type === "route") {
+            addRoute(name);
+        } else {
+            console.error(`Invalid type! Expected 'cx add route <name>', found 'cx add ${type} ${name}'.`);
+        }
     });
 
 program.parse();


### PR DESCRIPTION
Fixed an issue with adding a new route. A bug was introduced recently where adding a route worked only in this way:
- `cx add, sign-in ignored` (with a comma) - This would add a route with name `sign-in`.
instead of:
- `cx add route sign-in`