### PR TITLE
Document dataAdapter property

### DIFF
--- a/docs/app/DocsNav.js
+++ b/docs/app/DocsNav.js
@@ -322,6 +322,10 @@ export const docsNavTree = [
                   url: "~/examples/grid/infinite-scrolling",
                },
                {
+                  text: "Tree Grid",
+                  url: "~/examples/grid/tree-grid",
+               },
+               {
                   text: "Stateful Tree Grid",
                   url: "~/examples/grid/stateful-tree-grid",
                },

--- a/docs/content/examples/grid/TreeGrid.js
+++ b/docs/content/examples/grid/TreeGrid.js
@@ -1,13 +1,10 @@
-import {HtmlElement, TextField, Icon, Grid, TreeNode} from 'cx/widgets';
-import {Content, Controller, LabelsLeftLayout, KeySelection, TreeAdapter} from 'cx/ui';
-import {ExposedRecordView, Binding} from 'cx/data';
-import {Md} from '../../../components/Md';
-import {CodeSplit} from '../../../components/CodeSplit';
-import {CodeSnippet} from '../../../components/CodeSnippet';
-import {ConfigTable} from '../../../components/ConfigTable';
-
+import { Content, Grid, Tab, TreeNode } from 'cx/widgets';
+import { Controller, KeySelection, TreeAdapter } from 'cx/ui';
+import { Md } from '../../../components/Md';
+import { CodeSplit } from '../../../components/CodeSplit';
+import { CodeSnippet } from '../../../components/CodeSnippet';
+import { ConfigTable } from '../../../components/ConfigTable';
 import {casual} from '../data/casual';
-
 import configs from '../../widgets/configs/TreeNode';
 
 class PageController extends Controller {
@@ -17,7 +14,7 @@ class PageController extends Controller {
     }
 
     generateRecords(node) {
-        if (!node || node.$level < 5)
+        if (!node || node.$level < 5) {
             return Array.from({length: 20}).map(() => ({
                 id: ++this.idSeq,
                 fullName: casual.full_name,
@@ -27,6 +24,7 @@ class PageController extends Controller {
                 $leaf: casual.coin_flip,
                 //icon: 'circle'
             }));
+        }
     }
 }
 
@@ -71,64 +69,72 @@ export const TreeGrid = <cx>
                 ]}
             />
 
-            <CodeSnippet putInto="code" fiddle="riuObfzq">{`
+            <Content name="code">
+                <div>
+                    <Tab value-bind="$page.code.tab" tab="controller" mod="code" text="Controller" />
+                    <Tab value-bind="$page.code.tab" tab="grid" mod="code"  text="Grid" default/>
+                </div>
 
-            class PageController extends Controller {
-                onInit() {
-                    this.idSeq = 0;
-                    this.store.set('$page.data', this.generateRecords());
-                }
+                <CodeSnippet visible-expr="{$page.code.tab}=='controller'" fiddle="riuObfzq">{`
+                    class PageController extends Controller {
+                        onInit() {
+                            this.idSeq = 0;
+                            this.store.set('$page.data', this.generateRecords());
+                        }
 
-                generateRecords(node) {
-                    if (!node || node.$level < 5)
-                        return Array.from({length: 20}).map(() => ({
-                            id: ++this.idSeq,
-                            fullName: casual.full_name,
-                            phone: casual.phone,
-                            city: casual.city,
-                            notified: casual.coin_flip,
-                            $leaf: casual.coin_flip,
-                            //icon: 'circle'
-                        }));
-                }
-            }
-            ...
-
-            <Grid
-                buffered
-                records-bind='$page.data'
-                mod="tree"
-                style={{width: "100%", height: '500px'}}
-                scrollable={true}
-                dataAdapter={{
-                    type: TreeAdapter,
-                    load: (context, {controller}, node) => controller.generateRecords(node)
-                }}
-                selection={{type: KeySelection, bind: "$page.selection"}}
-                columns={[
-                    {
-                        header: 'Name', field: 'fullName', sortable: true, items: <cx>
-                        <TreeNode expanded-bind="$record.$expanded"
-                            leaf-bind="$record.$leaf"
-                            level-bind="$record.$level"
-                            loading-bind="$record.$loading"
-                            text-bind="$record.fullName"
-                            icon-bind="$record.icon"
-                        />
-                    </cx>
-                    },
-                    {header: 'Phone', field: 'phone'},
-                    {header: 'City', field: 'city', sortable: true},
-                    {
-                        header: 'Notified',
-                        field: 'notified',
-                        sortable: true,
-                        value: {expr: '{$record.notified} ? "Yes" : "No"'}
+                        generateRecords(node) {
+                            if (!node || node.$level < 5) {
+                                return Array.from({length: 20}).map(() => ({
+                                    id: ++this.idSeq,
+                                    fullName: casual.full_name,
+                                    phone: casual.phone,
+                                    city: casual.city,
+                                    notified: casual.coin_flip,
+                                    $leaf: casual.coin_flip,
+                                    //icon: 'circle'
+                                }));
+                            }
+                        }
                     }
-                ]}
-            />
-
-            `}</CodeSnippet>
+                `}
+                </CodeSnippet>
+                <CodeSnippet visible-expr="{$page.code.tab}=='grid'" fiddle="riuObfzq">{`
+                    <Grid
+                        buffered
+                        records-bind='$page.data'
+                        mod="tree"
+                        style={{width: "100%", height: '500px'}}
+                        scrollable={true}
+                        dataAdapter={{
+                            type: TreeAdapter,
+                            load: (context, {controller}, node) => controller.generateRecords(node)
+                        }}
+                        selection={{type: KeySelection, bind: "$page.selection"}}
+                        columns={[
+                            {
+                                header: 'Name', field: 'fullName', sortable: true, items: <cx>
+                                <TreeNode expanded-bind="$record.$expanded"
+                                    leaf-bind="$record.$leaf"
+                                    level-bind="$record.$level"
+                                    loading-bind="$record.$loading"
+                                    text-bind="$record.fullName"
+                                    icon-bind="$record.icon"
+                                />
+                            </cx>
+                            },
+                            {header: 'Phone', field: 'phone'},
+                            {header: 'City', field: 'city', sortable: true},
+                            {
+                                header: 'Notified',
+                                field: 'notified',
+                                sortable: true,
+                                value: {expr: '{$record.notified} ? "Yes" : "No"'}
+                            }
+                        ]}
+                    />
+                `}
+                </CodeSnippet>
+            </Content>
         </CodeSplit>
 
         ## `TreeNode` Configuration

--- a/docs/content/widgets/Grids.js
+++ b/docs/content/widgets/Grids.js
@@ -16,11 +16,8 @@ import columnConfigs from './configs/GridColumn';
 import columnHeaderConfigs from './configs/GridColumnHeader';
 
 class PageController extends Controller {
-    init() {
-        super.init();
-
-        //init grid data
-        this.store.init('$page.records', Array.from({length: 100}).map((v, i)=>({
+    onInit() {
+        this.store.init('$page.records', Array.from({length: 100}).map((v, i) => ({
             id: i + 1,
             fullName: casual.full_name,
             continent: casual.continent,
@@ -73,11 +70,8 @@ export const Grids = <cx>
                 <CodeSnippet visible-expr="{$page.code.tab}=='controller'" fiddle="kzHH3vkM">
                     {`
                         class PageController extends Controller {
-                            init() {
-                               super.init();
-
-                               //init grid data
-                               this.store.set('$page.records', Array.from({length: 10}).map((v, i)=>({
+                            onInit() {
+                               this.store.set('$page.records', Array.from({length: 10}).map((v, i) => ({
                                   id: i + 1,
                                   fullName: casual.full_name,
                                   continent: casual.continent,
@@ -87,11 +81,12 @@ export const Grids = <cx>
                                })));
                             }
                          }
-                        `}</CodeSnippet>
-                        <CodeSnippet visible-expr="{$page.code.tab}=='grid'" fiddle="kzHH3vkM">{`
-                        <Grid records-bind='$page.records'
-                            style={{width: "100%"}}
-                            columns={[
+                    `}
+                </CodeSnippet>
+                <CodeSnippet visible-expr="{$page.code.tab}=='grid'" fiddle="kzHH3vkM">{`
+                    <Grid records-bind='$page.records'
+                        style={{width: "100%"}}
+                        columns={[
                             { header: 'Name', field: 'fullName', sortable: true },
                             { header: 'Continent', field: 'continent', sortable: true },
                             { header: 'Browser', field: 'browser', sortable: true },
@@ -99,8 +94,8 @@ export const Grids = <cx>
                             { header: 'Visits', field: 'visits', sortable: true }
                         ]}
                         selection={{type: KeySelection, bind:'$page.selection'}}
-                        />
-                    `}
+                    />
+                `}
                 </CodeSnippet>
             </Content>
         </CodeSplit>

--- a/docs/content/widgets/TreeGrid.js
+++ b/docs/content/widgets/TreeGrid.js
@@ -14,7 +14,7 @@ class PageController extends Controller {
     }
 
     generateRecords(node) {
-        if (!node || node.$level < 5)
+        if (!node || node.$level < 5) {
             return Array.from({length: 20}).map(() => ({
                 id: ++this.idSeq,
                 fullName: casual.full_name,
@@ -24,6 +24,7 @@ class PageController extends Controller {
                 $leaf: casual.coin_flip,
                 //icon: 'circle'
             }));
+        }
     }
 }
 
@@ -75,62 +76,64 @@ export const TreeGrid = <cx>
                 </div>
 
                 <CodeSnippet visible-expr="{$page.code.tab}=='controller'" fiddle="riuObfzq">{`
-            class PageController extends Controller {
-                onInit() {
-                    this.idSeq = 0;
-                    this.store.set('$page.data', this.generateRecords());
-                }
+                    class PageController extends Controller {
+                        onInit() {
+                            this.idSeq = 0;
+                            this.store.set('$page.data', this.generateRecords());
+                        }
 
-                generateRecords(node) {
-                    if (!node || node.$level < 5)
-                        return Array.from({length: 20}).map(() => ({
-                            id: ++this.idSeq,
-                            fullName: casual.full_name,
-                            phone: casual.phone,
-                            city: casual.city,
-                            notified: casual.coin_flip,
-                            $leaf: casual.coin_flip,
-                            //icon: 'circle'
-                        }));
-                }
-            }
-            `}</CodeSnippet>
-            <CodeSnippet visible-expr="{$page.code.tab}=='grid'" fiddle="riuObfzq">{`
-            <Grid
-                buffered
-                records-bind='$page.data'
-                mod="tree"
-                style={{width: "100%", height: '500px'}}
-                scrollable={true}
-                dataAdapter={{
-                    type: TreeAdapter,
-                    load: (context, {controller}, node) => controller.generateRecords(node)
-                }}
-                selection={{type: KeySelection, bind: "$page.selection"}}
-                columns={[
-                    {
-                        header: 'Name', field: 'fullName', sortable: true, items: <cx>
-                        <TreeNode expanded-bind="$record.$expanded"
-                            leaf-bind="$record.$leaf"
-                            level-bind="$record.$level"
-                            loading-bind="$record.$loading"
-                            text-bind="$record.fullName"
-                            icon-bind="$record.icon"
-                        />
-                    </cx>
-                    },
-                    {header: 'Phone', field: 'phone'},
-                    {header: 'City', field: 'city', sortable: true},
-                    {
-                        header: 'Notified',
-                        field: 'notified',
-                        sortable: true,
-                        value: {expr: '{$record.notified} ? "Yes" : "No"'}
+                        generateRecords(node) {
+                            if (!node || node.$level < 5) {
+                                return Array.from({length: 20}).map(() => ({
+                                    id: ++this.idSeq,
+                                    fullName: casual.full_name,
+                                    phone: casual.phone,
+                                    city: casual.city,
+                                    notified: casual.coin_flip,
+                                    $leaf: casual.coin_flip,
+                                    //icon: 'circle'
+                                }));
+                            }
+                        }
                     }
-                ]}
-            />
-
-            `}</CodeSnippet>
+                `}
+                </CodeSnippet>
+                <CodeSnippet visible-expr="{$page.code.tab}=='grid'" fiddle="riuObfzq">{`
+                    <Grid
+                        buffered
+                        records-bind='$page.data'
+                        mod="tree"
+                        style={{width: "100%", height: '500px'}}
+                        scrollable={true}
+                        dataAdapter={{
+                            type: TreeAdapter,
+                            load: (context, {controller}, node) => controller.generateRecords(node)
+                        }}
+                        selection={{type: KeySelection, bind: "$page.selection"}}
+                        columns={[
+                            {
+                                header: 'Name', field: 'fullName', sortable: true, items: <cx>
+                                <TreeNode expanded-bind="$record.$expanded"
+                                    leaf-bind="$record.$leaf"
+                                    level-bind="$record.$level"
+                                    loading-bind="$record.$loading"
+                                    text-bind="$record.fullName"
+                                    icon-bind="$record.icon"
+                                />
+                            </cx>
+                            },
+                            {header: 'Phone', field: 'phone'},
+                            {header: 'City', field: 'city', sortable: true},
+                            {
+                                header: 'Notified',
+                                field: 'notified',
+                                sortable: true,
+                                value: {expr: '{$record.notified} ? "Yes" : "No"'}
+                            }
+                        ]}
+                    />
+                `}
+                </CodeSnippet>
             </Content>
         </CodeSplit>
 

--- a/docs/content/widgets/configs/Grid.js
+++ b/docs/content/widgets/configs/Grid.js
@@ -77,6 +77,12 @@ export default {
             maintain consistent looks across pages.
         </Md></cx>
     },
+    dataAdapter: {
+        type: 'object',
+        description: <cx><Md>
+            Data adapter is used in a `TreeGrid` for converting data in a list of records. Used to enable grouping and tree operations.
+        </Md></cx>
+    },
     defaultSortField: {
         type: 'string',
         key: false,

--- a/docs/content/widgets/configs/Grid.js
+++ b/docs/content/widgets/configs/Grid.js
@@ -80,7 +80,8 @@ export default {
     dataAdapter: {
         type: 'object',
         description: <cx><Md>
-            Data adapter is used in a `TreeGrid` for converting data in a list of records. Used to enable grouping and tree operations.
+            Data adapter is used for converting data in a list of records. Used to enable grouping and
+            tree operations. See [TreeGrid](~/widgets/tree-grid) for more details.
         </Md></cx>
     },
     defaultSortField: {

--- a/docs/content/widgets/configs/TreeNode.js
+++ b/docs/content/widgets/configs/TreeNode.js
@@ -9,7 +9,6 @@ export default {
             Base CSS class to be applied to the element. Default is 'treenode'.
         </Md></cx>
     },
-
     expanded: {
         type: 'boolean',
         key: true,


### PR DESCRIPTION
- Add `dataAdapter` property to Grid documentation.
- Update docs navigation to include `examples/grid/tree-grid`.
- Update `examples/grid/tree-grid` page:
  - Split controller and widgets code into separate tabs.
  - Fix formatting.