### PR TITLE
Add support for `target` property

### DIFF
--- a/docs/content/widgets/configs/LinkButton.js
+++ b/docs/content/widgets/configs/LinkButton.js
@@ -30,6 +30,14 @@ export default {
         </Md></cx>
     },
 
+    target: {
+        type: 'string',
+        key: true,
+        description: <cx><Md>
+            This attribute specifies where to open the linked document.
+        </Md></cx>
+    },
+
     match: {
         type: 'string',
         key: true,

--- a/packages/cx/src/widgets/nav/LinkButton.js
+++ b/packages/cx/src/widgets/nav/LinkButton.js
@@ -17,6 +17,7 @@ export class LinkButton extends Button {
          {
             href: undefined,
             url: undefined,
+            target: undefined,
             active: undefined,
             activeClass: undefined,
             activeStyle: undefined,


### PR DESCRIPTION
Useful e.g. for file download link buttons.