### PR TITLE
Add support for year selector in calendar

### DIFF
--- a/litmus/features/calendar/year-selection.js
+++ b/litmus/features/calendar/year-selection.js
@@ -1,5 +1,6 @@
 import { LabelsLeftLayout, createFunctionalComponent } from "cx/ui";
 import { DateField } from "cx/widgets";
+import Calendar from ".";
 
 export default createFunctionalComponent(() => {
    return (
@@ -9,6 +10,7 @@ export default createFunctionalComponent(() => {
                <DateField showTodayButton label="Full range" />
                <DateField showTodayButton label="Min date" minValue={new Date()} />
                <DateField showTodayButton label="Max range" maxValue={new Date()} />
+               <Calendar />
             </LabelsLeftLayout>
          </div>
       </cx>

--- a/litmus/features/calendar/year-selection.js
+++ b/litmus/features/calendar/year-selection.js
@@ -1,12 +1,14 @@
-import { LabelsLeftLayout, LabelsTopLayout, createFunctionalComponent } from "cx/ui";
-import { DateField, DateTimeField } from "cx/widgets";
+import { LabelsLeftLayout, createFunctionalComponent } from "cx/ui";
+import { DateField } from "cx/widgets";
 
 export default createFunctionalComponent(() => {
    return (
       <cx>
          <div>
             <LabelsLeftLayout>
-               <DateField showTodayButton label="Test" />
+               <DateField showTodayButton label="Full range" />
+               <DateField showTodayButton label="Min date" minValue={new Date()} />
+               <DateField showTodayButton label="Max range" maxValue={new Date()} />
             </LabelsLeftLayout>
          </div>
       </cx>

--- a/litmus/features/calendar/year-selection.js
+++ b/litmus/features/calendar/year-selection.js
@@ -1,0 +1,14 @@
+import { LabelsLeftLayout, LabelsTopLayout, createFunctionalComponent } from "cx/ui";
+import { DateField, DateTimeField } from "cx/widgets";
+
+export default createFunctionalComponent(() => {
+   return (
+      <cx>
+         <div>
+            <LabelsLeftLayout>
+               <DateField showTodayButton label="Test" />
+            </LabelsLeftLayout>
+         </div>
+      </cx>
+   );
+});

--- a/litmus/index.js
+++ b/litmus/index.js
@@ -118,7 +118,7 @@ import "./index.scss";
 //import Demo from "./features/formats/zeroPadFormat";
 //import Demo from "./bugs/window_dissmisses_on_dropdown_dismiss";
 // import Demo from "./bugs/grid-grouping-incorrect-text-prop-description";
-import Demo from "./bugs/MultipleLookupFieldValidation";
+import Demo from "./features/calendar/year-selection";
 
 let store = (window.store = new Store());
 

--- a/packages/cx/src/widgets/form/Calendar.js
+++ b/packages/cx/src/widgets/form/Calendar.js
@@ -408,6 +408,11 @@ export class CalendarCmp extends VDOM.Component {
    }
 
    renderYearDropdown() {
+      let { data } = this.props.instance;
+      let minYear = data.minValue?.getFullYear();
+      let maxYear = data.maxValue?.getFullYear();
+      let { CSS } = this.props.instance.widget;
+
       let years = [];
       let currentYear = new Date().getFullYear();
       let refYear = new Date(this.state.refDate).getFullYear();
@@ -421,14 +426,14 @@ export class CalendarCmp extends VDOM.Component {
       }
       return (
          <div
-            className={this.props.instance.widget.CSS.element(this.props.instance.widget.baseClass, "year-dropdown")}
+            className={CSS.element(this.props.instance.widget.baseClass, "year-dropdown")}
             ref={(el) => {
                if (el) {
                   el.addEventListener("wheel", (e) => {
                      e.stopPropagation();
                   });
 
-                  let activeYear = el.querySelector(".active");
+                  let activeYear = el.querySelector(".cxs-active");
                   if (activeYear) activeYear.scrollIntoView({ block: "center", behavior: "instant" });
                }
             }}
@@ -440,12 +445,10 @@ export class CalendarCmp extends VDOM.Component {
                         {row.map((year) => (
                            <td
                               key={year}
-                              className={
-                                 this.props.instance.widget.CSS.element(
-                                    this.props.instance.widget.baseClass,
-                                    "year-option",
-                                 ) + (year === refYear ? " active" : "")
-                              }
+                              className={CSS.element(this.props.instance.widget.baseClass, "year-option", {
+                                 unselectable: (minYear && year < minYear) || (maxYear && year > maxYear),
+                                 active: year === refYear,
+                              })}
                               onMouseDown={(e) => this.handleYearSelect(e, year)}
                            >
                               {year}

--- a/packages/cx/src/widgets/form/Calendar.js
+++ b/packages/cx/src/widgets/form/Calendar.js
@@ -175,8 +175,7 @@ export class CalendarCmp extends VDOM.Component {
             hover: false,
             focus: false,
             cursor: zeroTime(data.date || refDate),
-            showYearDropdown: false,
-            showCalendar: true,
+            activeView: "calendar",
          },
          this.getPage(refDate),
       );
@@ -389,8 +388,7 @@ export class CalendarCmp extends VDOM.Component {
 
    toggleYearDropdown() {
       this.setState({
-         showYearDropdown: !this.state.showYearDropdown,
-         showCalendar: this.state.showYearDropdown,
+         activeView: this.state.activeView === "calendar" ? "year-selection" : "calendar",
       });
    }
 
@@ -402,12 +400,11 @@ export class CalendarCmp extends VDOM.Component {
       this.setState({
          ...this.getPage(refDate),
          refDate,
-         showYearDropdown: false,
-         showCalendar: true,
+         activeView: "calendar",
       });
    }
 
-   renderYearDropdown() {
+   renderYearSelection() {
       let { data } = this.props.instance;
       let minYear = data.minValue?.getFullYear();
       let maxYear = data.maxValue?.getFullYear();
@@ -426,7 +423,7 @@ export class CalendarCmp extends VDOM.Component {
       }
       return (
          <div
-            className={CSS.element(this.props.instance.widget.baseClass, "year-dropdown")}
+            className={CSS.element(this.props.instance.widget.baseClass, "year-selection")}
             ref={(el) => {
                if (el) {
                   el.addEventListener("wheel", (e) => {
@@ -546,7 +543,7 @@ export class CalendarCmp extends VDOM.Component {
             onFocus={(e) => this.handleFocus(e)}
             onBlur={(e) => this.handleBlur(e)}
          >
-            {this.state.showCalendar && (
+            {this.state.activeView == "calendar" && (
                <table>
                   <thead>
                      <tr key="h" className={CSS.element(baseClass, "header")}>
@@ -586,7 +583,7 @@ export class CalendarCmp extends VDOM.Component {
                   <tbody>{weeks}</tbody>
                </table>
             )}
-            {this.state.showCalendar && widget.showTodayButton && (
+            {this.state.activeView == "calendar" && widget.showTodayButton && (
                <div className={CSS.element(baseClass, "toolbar")}>
                   <button
                      className={CSS.expand(CSS.element(baseClass, "today-button"), CSS.block("button", "hollow"))}
@@ -602,7 +599,7 @@ export class CalendarCmp extends VDOM.Component {
                </div>
             )}
 
-            {this.state.showYearDropdown && this.renderYearDropdown()}
+            {this.state.activeView == "year-selection" && this.renderYearSelection()}
          </div>
       );
    }

--- a/packages/cx/src/widgets/form/Calendar.js
+++ b/packages/cx/src/widgets/form/Calendar.js
@@ -387,9 +387,10 @@ export class CalendarCmp extends VDOM.Component {
       tooltipParentWillUnmount(this.props.instance);
    }
 
-   toggleYearDropdown() {
+   showYearDropdown() {
       this.setState({
-         activeView: this.state.activeView === "calendar" ? "year-picker" : "calendar",
+         activeView: "year-picker",
+         yearPickerHeight: this.el.firstChild.offsetHeight,
       });
    }
 
@@ -406,32 +407,36 @@ export class CalendarCmp extends VDOM.Component {
    }
 
    renderYearPicker() {
-      let { data } = this.props.instance;
+      let { data, widget } = this.props.instance;
       let minYear = data.minValue?.getFullYear();
       let maxYear = data.maxValue?.getFullYear();
       let { CSS } = this.props.instance.widget;
 
       let years = [];
       let currentYear = new Date().getFullYear();
+      let midYear = currentYear - (currentYear % 5);
       let refYear = new Date(this.state.refDate).getFullYear();
-      for (let i = currentYear - 100; i <= currentYear + 100; i++) {
+      for (let i = midYear - 100; i <= midYear + 100; i++) {
          years.push(i);
       }
 
       let rows = [];
-      for (let i = 0; i < years.length; i += 3) {
-         rows.push(years.slice(i, i + 3));
+      for (let i = 0; i < years.length; i += 5) {
+         rows.push(years.slice(i, i + 5));
       }
       return (
          <div
-            className={CSS.element(this.props.instance.widget.baseClass, "year-picker")}
+            className={CSS.element(widget.baseClass, "year-picker")}
+            style={{
+               height: this.state.yearPickerHeight,
+            }}
             ref={(el) => {
                if (el) {
                   el.addEventListener("wheel", (e) => {
                      e.stopPropagation();
                   });
 
-                  let activeYear = el.querySelector(".cxs-active");
+                  let activeYear = el.querySelector("." + CSS.state("selected"));
                   if (activeYear) activeYear.scrollIntoView({ block: "center", behavior: "instant" });
                }
             }}
@@ -445,9 +450,10 @@ export class CalendarCmp extends VDOM.Component {
                               key={year}
                               className={CSS.element(this.props.instance.widget.baseClass, "year-option", {
                                  unselectable: (minYear && year < minYear) || (maxYear && year > maxYear),
-                                 active: year === refYear,
+                                 selected: year === refYear,
+                                 active: year === currentYear,
                               })}
-                              onMouseDown={(e) => this.handleYearSelect(e, year)}
+                              onClick={(e) => this.handleYearSelect(e, year)}
                            >
                               {year}
                            </td>
@@ -559,7 +565,7 @@ export class CalendarCmp extends VDOM.Component {
                            {monthNames[month]}
                            <br />
                            <span
-                              onClick={() => this.toggleYearDropdown()}
+                              onClick={() => this.showYearDropdown()}
                               className={CSS.element(baseClass, "year-name")}
                            >
                               {year}

--- a/packages/cx/src/widgets/form/Calendar.js
+++ b/packages/cx/src/widgets/form/Calendar.js
@@ -368,6 +368,7 @@ export class CalendarCmp extends VDOM.Component {
       if (this.props.instance.widget.autoFocus) this.el.focus();
 
       tooltipParentDidMount(this.el, ...getFieldTooltip(this.props.instance));
+      this.el.addEventListener("wheel", (e) => this.handleWheel(e));
    }
 
    UNSAFE_componentWillReceiveProps(props) {
@@ -539,7 +540,7 @@ export class CalendarCmp extends VDOM.Component {
             onMouseMove={(e) => tooltipMouseMove(e, ...getFieldTooltip(this.props.instance))}
             onMouseLeave={(e) => this.handleMouseLeave(e)}
             onMouseEnter={(e) => this.handleMouseEnter(e)}
-            onWheel={(e) => this.handleWheel(e)}
+            // onWheel={(e) => this.handleWheel(e)}
             onFocus={(e) => this.handleFocus(e)}
             onBlur={(e) => this.handleBlur(e)}
          >

--- a/packages/cx/src/widgets/form/Calendar.js
+++ b/packages/cx/src/widgets/form/Calendar.js
@@ -388,7 +388,7 @@ export class CalendarCmp extends VDOM.Component {
 
    toggleYearDropdown() {
       this.setState({
-         activeView: this.state.activeView === "calendar" ? "year-selection" : "calendar",
+         activeView: this.state.activeView === "calendar" ? "year-picker" : "calendar",
       });
    }
 
@@ -404,7 +404,7 @@ export class CalendarCmp extends VDOM.Component {
       });
    }
 
-   renderYearSelection() {
+   renderYearPicker() {
       let { data } = this.props.instance;
       let minYear = data.minValue?.getFullYear();
       let maxYear = data.maxValue?.getFullYear();
@@ -423,7 +423,7 @@ export class CalendarCmp extends VDOM.Component {
       }
       return (
          <div
-            className={CSS.element(this.props.instance.widget.baseClass, "year-selection")}
+            className={CSS.element(this.props.instance.widget.baseClass, "year-picker")}
             ref={(el) => {
                if (el) {
                   el.addEventListener("wheel", (e) => {
@@ -599,7 +599,7 @@ export class CalendarCmp extends VDOM.Component {
                </div>
             )}
 
-            {this.state.activeView == "year-selection" && this.renderYearSelection()}
+            {this.state.activeView == "year-picker" && this.renderYearPicker()}
          </div>
       );
    }

--- a/packages/cx/src/widgets/form/Calendar.scss
+++ b/packages/cx/src/widgets/form/Calendar.scss
@@ -144,7 +144,6 @@
       }
 
       &-picker {
-         @include cx-add-state-rules($cx-calendar-day-state-style-map, default); // maybe different map
          user-select: none;
          overflow-y: scroll;
          width: 100%;
@@ -153,15 +152,19 @@
       }
 
       &-option {
-         padding: 5px;
          cursor: pointer;
+         @include cx-add-state-rules($cx-calendar-day-state-style-map, default);
 
-         &.cxs-active {
-            @include cx-add-state-rules($cx-calendar-day-state-style-map, today); // maybe different map
+         &.#{$state}active {
+            @include cx-add-state-rules($cx-calendar-day-state-style-map, today);
          }
 
          &:hover {
-            @include cx-add-state-rules($cx-calendar-day-state-style-map, hover); // maybe different map
+            @include cx-add-state-rules($cx-calendar-day-state-style-map, hover);
+         }
+
+         &.#{$state}selected {
+            @include cx-add-state-rules($cx-calendar-day-state-style-map, selected);
          }
       }
    }

--- a/packages/cx/src/widgets/form/Calendar.scss
+++ b/packages/cx/src/widgets/form/Calendar.scss
@@ -91,8 +91,8 @@
          }
       }
 
-      td:first-child,
-      td:last-child {
+      td:not(.cxe-calendar-year-option):first-child,
+      td:not(.cxe-calendar-year-option):last-child {
          display: none;
          pointer-events: none;
       }
@@ -135,6 +135,33 @@
       font-size: $icon-size;
       line-height: $icon-size;
       user-select: none;
+   }
+
+   .#{$element}#{$name}-year {
+      &-name {
+         cursor: pointer;
+      }
+
+      &-dropdown {
+         @include cx-add-state-rules($cx-calendar-day-state-style-map, default); // maybe different map
+         user-select: none;
+         overflow-y: auto;
+         height: 18em;
+         width: 18em;
+      }
+
+      &-option {
+         padding: 5px;
+         cursor: pointer;
+
+         &.active {
+            @include cx-add-state-rules($cx-calendar-day-state-style-map, today); // maybe different map
+         }
+
+         &:hover {
+            @include cx-add-state-rules($cx-calendar-day-state-style-map, hover); // maybe different map
+         }
+      }
    }
 
    .#{$element}#{$name}-icon-prev-year {

--- a/packages/cx/src/widgets/form/Calendar.scss
+++ b/packages/cx/src/widgets/form/Calendar.scss
@@ -16,6 +16,7 @@
       display: inline-block;
       vertical-align: middle;
       width: 18em;
+      overflow-y: auto;
       box-sizing: border-box;
 
       &:hover {
@@ -145,15 +146,17 @@
       &-dropdown {
          @include cx-add-state-rules($cx-calendar-day-state-style-map, default); // maybe different map
          user-select: none;
-         overflow-y: auto;
-         height: 18em;
+         overflow-y: scroll;
+         width: 100%;
+         max-height: 24em;
+         height: auto;
       }
 
       &-option {
          padding: 5px;
          cursor: pointer;
 
-         &.active {
+         &.cxs-active {
             @include cx-add-state-rules($cx-calendar-day-state-style-map, today); // maybe different map
          }
 

--- a/packages/cx/src/widgets/form/Calendar.scss
+++ b/packages/cx/src/widgets/form/Calendar.scss
@@ -143,7 +143,7 @@
          cursor: pointer;
       }
 
-      &-selection {
+      &-picker {
          @include cx-add-state-rules($cx-calendar-day-state-style-map, default); // maybe different map
          user-select: none;
          overflow-y: scroll;

--- a/packages/cx/src/widgets/form/Calendar.scss
+++ b/packages/cx/src/widgets/form/Calendar.scss
@@ -143,7 +143,7 @@
          cursor: pointer;
       }
 
-      &-dropdown {
+      &-selection {
          @include cx-add-state-rules($cx-calendar-day-state-style-map, default); // maybe different map
          user-select: none;
          overflow-y: scroll;

--- a/packages/cx/src/widgets/form/Calendar.scss
+++ b/packages/cx/src/widgets/form/Calendar.scss
@@ -146,8 +146,7 @@
          @include cx-add-state-rules($cx-calendar-day-state-style-map, default); // maybe different map
          user-select: none;
          overflow-y: auto;
-         height: 16em;
-         width: 16em;
+         height: 18em;
       }
 
       &-option {

--- a/packages/cx/src/widgets/form/Calendar.scss
+++ b/packages/cx/src/widgets/form/Calendar.scss
@@ -146,8 +146,8 @@
          @include cx-add-state-rules($cx-calendar-day-state-style-map, default); // maybe different map
          user-select: none;
          overflow-y: auto;
-         height: 18em;
-         width: 18em;
+         height: 16em;
+         width: 16em;
       }
 
       &-option {


### PR DESCRIPTION
When selecting something like a date of birth, we need to scroll through the years a lot. 
Now, you can click on the year, select a proper year, and then select the date. 