### PR TITLE
Fix issue with clearable sort

### DIFF
--- a/litmus/bugs/grid-clearable-sort.js
+++ b/litmus/bugs/grid-clearable-sort.js
@@ -1,0 +1,42 @@
+import { KeySelection } from "cx/ui";
+import { Grid, PureContainer } from "cx/widgets";
+
+export default () => (
+   <cx>
+      <PureContainer
+         controller={{
+            init() {
+               this.store.init(
+                  "$page.records",
+                  Array.from({ length: 100 }).map((v, i) => ({
+                     id: i + 1,
+                     fullName: "Mike",
+                     continent: "Europe",
+                     browser: "Chrome",
+                     os: "Windows",
+                     visits: 1,
+                  })),
+               );
+            },
+         }}
+      >
+         <Grid
+            records-bind="$page.records"
+            style={{ height: "300px" }}
+            mod="responsive"
+            scrollable
+            columns={[
+               { header: "Name", field: "fullName", sortable: true },
+               { header: "Continent", field: "continent", sortable: true },
+               { header: "Browser", field: "browser", sortable: true },
+               { header: "OS", field: "os", sortable: true },
+               { header: "Visits", field: "visits", sortable: true, align: "right" },
+            ]}
+            selection={{ type: KeySelection, bind: "$page.selection" }}
+            sortField-bind="field"
+            sortDirection-bind="sortDirection"
+            clearableSort
+         />
+      </PureContainer>
+   </cx>
+);

--- a/litmus/index.js
+++ b/litmus/index.js
@@ -119,7 +119,8 @@ import "./index.scss";
 //import Demo from "./bugs/window_dissmisses_on_dropdown_dismiss";
 // import Demo from "./bugs/grid-grouping-incorrect-text-prop-description";
 // import Demo from "./features/calendar/year-selection";
-import Demo from "./features/charts/column/ColumnGraphVSColumnZeroHeight";
+// import Demo from "./features/charts/column/ColumnGraphVSColumnZeroHeight";
+import Demo from "./bugs/grid-clearable-sort";
 
 let store = (window.store = new Store());
 

--- a/packages/cx/src/widgets/grid/Grid.js
+++ b/packages/cx/src/widgets/grid/Grid.js
@@ -657,7 +657,6 @@ export class Grid extends Container {
 
                   if (hdwidget.sortable && header.widget.allowSorting) {
                      mods.push("sortable");
-
                      if (data.sorters && data.sorters[0].field == (hdwidget.sortField || hdwidget.field)) {
                         mods.push("sorted-" + data.sorters[0].direction.toLowerCase());
                         sortIcon = <DropDownIcon className={CSS.element(baseClass, "column-sort-icon")} />;
@@ -859,6 +858,8 @@ export class Grid extends Container {
                  },
               ]
             : null;
+
+         field = sorters ? field : null;
 
          instance.set("sorters", sorters);
          instance.set("sortField", field);

--- a/packages/cx/src/widgets/grid/Grid.js
+++ b/packages/cx/src/widgets/grid/Grid.js
@@ -859,7 +859,7 @@ export class Grid extends Container {
               ]
             : null;
 
-         field = sorters ? field : null;
+         if (sorters == null) field = null;
 
          instance.set("sorters", sorters);
          instance.set("sortField", field);


### PR DESCRIPTION
When we add sortDirection and sortField bindings to the Grid, prepareData always initializes the sorters array, since it has sortField. This causes issues, since the only check when applying mods is to see if there are sorters, or if the name is defined (it always is).