### PR TITLE
Add monthPickerOptions to the MonthField component

### DIFF
--- a/litmus/features/month-field/withMonthPickerOptions.js
+++ b/litmus/features/month-field/withMonthPickerOptions.js
@@ -1,0 +1,29 @@
+import { LabelsLeftLayout } from "cx/ui";
+import { LabeledContainer, MonthField, MonthPicker, NumberField } from "cx/widgets";
+
+export default () => (
+   <cx>
+      <div
+         style="margin: 20px;"
+         controller={{
+            onInit() {
+               this.store.set("$page.value", new Date());
+               this.store.set("$page.value2", new Date());
+               this.store.set("$page.value3", new Date());
+               this.store.set("$page.value4", new Date());
+            },
+         }}
+      >
+         <LabelsLeftLayout vertical>
+            <LabeledContainer label="Normal Month Field">
+               <MonthField value-bind="$page.value" />
+               <span text-tpl="{$page.value:d}" style="font-size: 14px; margin: 10px" />
+            </LabeledContainer>
+            <LabeledContainer label="With month picker options">
+               <MonthField value-bind="$page.value2" monthPickerOptions={{ startYear: 2024, endYear: 2029 }} />
+               <span text-tpl="{$page.value2:d}" style="font-size: 14px; margin: 10px" />
+            </LabeledContainer>
+         </LabelsLeftLayout>
+      </div>
+   </cx>
+);

--- a/litmus/index.js
+++ b/litmus/index.js
@@ -131,9 +131,11 @@ import "./index.scss";
 //import Demo from "./dev/createHotPromiseWindowFactory";
 //import Demo from "./features/date/invariantParseDate";
 // import Demo from "./features/month-field/encoding";
+// import Demo from "./features/month-field/startEndYear";
+import Demo from "./features/month-field/withMonthPickerOptions";
 //import Demo from "./features/typescript/AccessorChainMethods";
 // import Demo from "./features/grid/CellEditing";
-import Demo from "./features/charts/PointReducer";
+// import Demo from "./features/charts/PointReducer";
 
 let store = (window.store = new Store());
 

--- a/packages/cx/src/widgets/form/MonthField.d.ts
+++ b/packages/cx/src/widgets/form/MonthField.d.ts
@@ -94,6 +94,11 @@ interface MonthFieldProps extends FieldProps {
    /** A boolean flag that determines whether the `to` date is included in the range.
     * When set to true the value stored in the to field would be the last day of the month, i.e. `2024-12-31`. */
    inclusiveTo?: boolean;
+
+   /** Optional configuration options for the MonthPicker component rendered within the dropdown.
+    * You can pass any valid additional MonthPicker props here, such as `startYear`, `endYear`, etc.
+    * Refer to the MonthPicker component documentation for a full list of supported options. */
+   monthPickerOptions?: Cx.Config;
 }
 
 export class MonthField extends Cx.Widget<MonthFieldProps> {}

--- a/packages/cx/src/widgets/form/MonthField.js
+++ b/packages/cx/src/widgets/form/MonthField.js
@@ -149,6 +149,7 @@ export class MonthField extends Field {
             data={instance.data}
             instance={instance}
             monthPicker={{
+               ...this.monthPickerOptions,
                value: this.value,
                from: this.from,
                to: this.to,

--- a/packages/cx/src/widgets/form/MonthPicker.js
+++ b/packages/cx/src/widgets/form/MonthPicker.js
@@ -193,7 +193,7 @@ export class MonthPickerComponent extends VDOM.Component {
          cursorQuarter: cursor.getMonth() / 3,
          column: "M",
          start: widget.startYear,
-         end: widget.startYear + widget.bufferSize,
+         end: Math.min(widget.startYear + widget.bufferSize, widget.endYear),
       };
 
       this.handleMouseDown = this.handleMouseDown.bind(this);


### PR DESCRIPTION
Allow passing additional config options to the MonthPicker rendered within a dropdown of MonthField component.