### PR TITLE
Set loading to false when triggering onFetchRecords by filterParams

### DIFF
--- a/packages/cx/src/widgets/grid/Grid.js
+++ b/packages/cx/src/widgets/grid/Grid.js
@@ -2602,6 +2602,7 @@ class GridComponent extends VDOM.Component {
                instance.buffer.totalRecordCount = 0;
                instance.buffer.page = 1;
                this.prevFetchRecordsState = null;
+               this.loading = false;
             }
          }
 


### PR DESCRIPTION
Reset loading when onFetchRecords is triggered by a filterParams change.