### PR TITLE
Fix text ellipsis on single-mode LookupField (#1287)

### DIFF
--- a/homedocs/src/pages/changelog.mdx
+++ b/homedocs/src/pages/changelog.mdx
@@ -4,6 +4,14 @@ title: Changelog
 description: Version history and release notes
 ---
 
+## cx\@26.4.4
+
+**Fixes**
+
+- Restored text ellipsis on single-selection `LookupField` when the selected value overflows the field width. Baseline alignment with adjacent fields and buttons is preserved ([#1287](https://github.com/codaxy/cxjs/issues/1287))
+
+---
+
 ## cx\@26.4.3
 
 **Fixes**

--- a/packages/cx/package.json
+++ b/packages/cx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cx",
-  "version": "26.4.3",
+  "version": "26.4.4",
   "description": "Advanced JavaScript UI framework for admin and dashboard applications with ready to use grid, form and chart components.",
   "exports": {
     "./data": {

--- a/packages/cx/src/widgets/form/LookupField.scss
+++ b/packages/cx/src/widgets/form/LookupField.scss
@@ -65,6 +65,7 @@
          $overrides: (
             default: (
                width: 100%,
+               // inline-flex preserves baseline alignment with sibling fields/buttons; ellipsis is applied on the inner -text span
                display: inline-flex,
                text-overflow: null,
                padding: cx-top($padding)
@@ -75,9 +76,6 @@
       );
 
       .#{$state}single > & {
-         overflow: hidden;
-         text-overflow: ellipsis;
-         white-space: nowrap;
          flex-basis: 0%;
          flex-grow: 1;
       }
@@ -85,6 +83,15 @@
       .#{$state}icon > & {
          padding-left: cx-calc(cx-top($padding), $cx-default-input-left-tool-size, $cx-default-input-left-tool-spacing);
       }
+   }
+
+   .#{$element}#{$name}-text {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      min-width: 0;
+      flex-basis: 0%;
+      flex-grow: 1;
    }
 
    .#{$element}#{$name}-tags {

--- a/packages/cx/src/widgets/form/LookupField.tsx
+++ b/packages/cx/src/widgets/form/LookupField.tsx
@@ -1099,9 +1099,12 @@ class LookupComponent extends VDOM.Component<
         text = this.getPlaceholder(data.placeholder);
       }
     } else {
-      text = !data.empty
+      let content = !data.empty
         ? data.text || this.getPlaceholder()
         : this.getPlaceholder(data.placeholder);
+      text = (
+        <span className={CSS.element(baseClass, "text")}>{content}</span>
+      );
     }
 
     let states = {


### PR DESCRIPTION
## Summary
- Wrap `{text}` in a `<span class="cxe-lookupfield-text">` inside the `-input` div in single-selection mode
- Move `overflow: hidden`, `text-overflow: ellipsis`, `white-space: nowrap` onto the new `-text` class
- Keep `-input` as `display: inline-flex` so baseline alignment with adjacent fields/buttons is preserved

The regression was introduced in the "Redo themes" PR (#1281), which changed `-input`'s default display to `inline-flex`. Flex containers can't apply `text-overflow: ellipsis` to direct text children (they become anonymous flex items). Moving the ellipsis onto a styleable child span is the fix.

Closes #1287

## Test plan
- [x] Open the `LookupField` homedocs example, select an option long enough to overflow → text is ellipsized with `…`
- [x] Place a `LookupField` next to a `Button` or text label → baselines align
- [x] Multi-selection mode unchanged (tags render as before)
- [x] Placeholder rendering unchanged (still wrapped in the same placeholder span, now inside `-text`)