### PR TITLE
Add `daybefore` date formatter

### DIFF
--- a/homedocs/src/pages/docs/intro/formatting.mdx
+++ b/homedocs/src/pages/docs/intro/formatting.mdx
@@ -168,6 +168,15 @@ Date and time patterns can be combined: `d;yyyyMMddHHmm` formats both date and t
 
 For more details on culture-sensitive formatting, see [intl-io](https://github.com/codaxy/intl-io).
 
+### Day-Before Format
+
+The `daybefore` format renders a date shifted back by one calendar day. It accepts the same pattern argument as `datetime`, which makes it convenient for displaying the *exclusive* end of a date range as an inclusive value — for example, a period running from `2020-01-01` up to (but not including) `2021-01-01` can be shown as `Dec 2020`.
+
+| Format               | Example Input | Example Output |
+| -------------------- | ------------- | -------------- |
+| `daybefore;MMM yyyy` | `2021-01-01`  | `Dec 2020`     |
+| `daybefore;yyyyMMdd` | `2021-01-01`  | `12/31/2020`   |
+
 ## Programmatic Formatting
 
 Use `Format.value()` to format values in code:

--- a/packages/cx/src/ui/Format.ts
+++ b/packages/cx/src/ui/Format.ts
@@ -2,7 +2,7 @@ import { Culture, getCurrentCultureCache } from "./Culture";
 import { Format as Fmt, resolveMinMaxFractionDigits, setGetFormatCacheCallback } from "../util/Format";
 import { setGetExpressionCacheCallback } from "../data/Expression";
 import { setGetStringTemplateCacheCallback } from "../data/StringTemplate";
-import { parseDateInvariant } from "../util";
+import { dayBefore, parseDateInvariant } from "../util";
 import { GlobalCacheIdentifier } from "../util/GlobalCacheIdentifier";
 
 export const Format = Fmt;
@@ -84,6 +84,12 @@ export function enableCultureSensitiveFormatting() {
       let culture = Culture.getDateTimeCulture();
       let formatter = culture.getFormatter(format);
       return (value: any) => formatter.format(parseDateInvariant(value));
+   });
+
+   Fmt.registerFactory(["dayBefore", "daybefore"], (fmt: any, format = "yyyyMd hhmm") => {
+      let culture = Culture.getDateTimeCulture();
+      let formatter = culture.getFormatter(format);
+      return (value: any) => formatter.format(dayBefore(parseDateInvariant(value)));
    });
 
    setGetFormatCacheCallback(() => {

--- a/packages/cx/src/util/Format.spec.ts
+++ b/packages/cx/src/util/Format.spec.ts
@@ -47,6 +47,17 @@ describe("Format", function () {
       });
    });
 
+   describe("daybefore", function () {
+      it("formats the date shifted back by one day", function () {
+         assert.equal(Format.value(new Date(2015, 3, 1, 5, 6, 14), "daybefore"), "3/31/2015 05:06");
+         assert.equal(Format.value(new Date(2015, 3, 1, 5, 6, 14), "dayBefore"), "3/31/2015 05:06");
+      });
+
+      it("steps back across month and year boundaries", function () {
+         assert.equal(Format.value(new Date(2021, 0, 1), "daybefore"), "12/31/2020 00:00");
+      });
+   });
+
    describe("ellipsis", function () {
       it("can shorten long texts", function () {
          assert.equal(Format.value("This is a very long text.", "ellipsis;7"), "This...");

--- a/packages/cx/src/util/Format.ts
+++ b/packages/cx/src/util/Format.ts
@@ -5,6 +5,7 @@ import { isUndefined } from "../util/isUndefined";
 import { isArray } from "../util/isArray";
 import { capitalize } from "./capitalize";
 import { parseDateInvariant } from "./date/parseDateInvariant";
+import { dayBefore } from "./date/dayBefore";
 
 //Culture dependent formatters are defined in the ui package.
 
@@ -98,6 +99,11 @@ let formatFactory: Record<string, (...args: any[]) => (value: any) => string> = 
       return (value: any) => date(value) + " " + time(value);
    },
 
+   dayBefore: function () {
+      let datetime = formatFactory.datetime();
+      return (value: any) => datetime(dayBefore(parseDateInvariant(value)));
+   },
+
    ellipsis: function (part0, length, where) {
       length = Number(length);
       if (!(length > 3)) length = 10;
@@ -168,6 +174,7 @@ formatFactory.ps = formatFactory.percentageSign;
 formatFactory.d = formatFactory.date;
 formatFactory.t = formatFactory.time;
 formatFactory.dt = formatFactory.datetime;
+formatFactory.daybefore = formatFactory.dayBefore;
 formatFactory.zeropad = formatFactory.zeroPad;
 formatFactory.leftpad = formatFactory.leftPad;
 formatFactory.capitalize = formatFactory.capitalize;

--- a/packages/cx/src/util/date/dayBefore.ts
+++ b/packages/cx/src/util/date/dayBefore.ts
@@ -1,0 +1,15 @@
+/**
+ * Returns a new `Date` representing the calendar day before the given date,
+ * keeping the same time of day. Month and year boundaries are handled
+ * automatically. The input is not mutated.
+ *
+ * Useful for displaying the exclusive end of a date range as an inclusive
+ * value, e.g. a period ending at `2021-01-01` shown as `Dec 2020`.
+ * @param date
+ * @returns {Date}
+ */
+export function dayBefore(date: Date): Date {
+   let result = new Date(date.getTime());
+   result.setDate(result.getDate() - 1);
+   return result;
+}

--- a/packages/cx/src/util/date/index.ts
+++ b/packages/cx/src/util/date/index.ts
@@ -1,4 +1,5 @@
 export * from "./dateDiff";
+export * from "./dayBefore";
 export * from "./zeroTime";
 export * from "./monthStart";
 export * from "./lowerBoundCheck";


### PR DESCRIPTION
## Summary

Adds a `daybefore` formatter that renders a date shifted back by one calendar day, using the same pattern argument as `datetime`.

It's handy for displaying the **exclusive** end of a date range as an inclusive value — e.g. a period running from `2020-01-01` up to (but not including) `2021-01-01` can be shown as `Dec 2020`.

```
daybefore;MMM yyyy   2021-01-01  ->  "Dec 2020"
daybefore;yyyyMMdd   2021-01-01  ->  "12/31/2020"
```

## Changes

- **`util/date/dayBefore.ts`** (new) — `dayBefore(date: Date): Date` helper returning the previous calendar day (no mutation; accepts an already-parsed `Date`).
- **`util/Format.ts`** — basic `dayBefore` formatter + `daybefore` alias, mirroring basic `datetime`.
- **`ui/Format.ts`** — culture-sensitive `dayBefore`/`daybefore` formatter, same pattern argument and `"yyyyMd hhmm"` default as `datetime`.
- **`util/Format.spec.ts`** — tests for the day shift and month/year boundary crossing.
- **`homedocs/.../formatting.mdx`** — a "Day-Before Format" docs subsection.

## Testing

- `Format` test suite: 13 passing (including 2 new `daybefore` cases).
- `yarn check-types`: clean.

Closes #1290