### PR TITLE
Fix ValidationGroup visited flag not propagating to fields

### DIFF
--- a/packages/cx/src/widgets/form/Field.tsx
+++ b/packages/cx/src/widgets/form/Field.tsx
@@ -312,6 +312,7 @@ export class Field<
     data._readOnly = data.readOnly;
     data._viewMode = data.mode === "view" || data.viewMode;
     data._tabOnEnterKey = data.tabOnEnterKey;
+    data._visited = data.visited;
     data.validationValue = this.getValidationValue(data);
     instance.parentDisabled = context.parentDisabled;
     instance.parentReadOnly = context.parentReadOnly;
@@ -366,7 +367,7 @@ export class Field<
     );
     data.visited = coalesce(
       context.parentStrict ? context.parentVisited : null,
-      data.visited,
+      data._visited,
       context.parentVisited,
     );
 

--- a/packages/cx/src/widgets/form/ValidationGroup.spec.tsx
+++ b/packages/cx/src/widgets/form/ValidationGroup.spec.tsx
@@ -1,8 +1,9 @@
 import { Store } from "../../data/Store";
 import { ValidationGroup } from "./ValidationGroup";
 import { Validator } from "./Validator";
+import { TextField } from "./TextField";
 import { bind } from "../../ui/bind";
-import { createTestRenderer } from "../../util/test/createTestRenderer";
+import { createTestRenderer, act } from "../../util/test/createTestRenderer";
 
 import assert from "assert";
 
@@ -105,6 +106,34 @@ describe("ValidationGroup", () => {
 
       let tree = component.toJSON();
       assert(visited);
+   });
+
+   it("visited flag changes are propagated to fields after being initialized to false", async () => {
+      let widget = (
+         <cx>
+            <ValidationGroup errors={bind("errors")} visited={bind("form.visited")}>
+               <TextField required value={bind("value1")} />
+            </ValidationGroup>
+         </cx>
+      );
+
+      let store = new Store();
+      //initializing the bound value to false used to shadow later updates
+      store.set("form.visited", false);
+
+      const component = await createTestRenderer(store, widget);
+
+      let errors = store.get("errors");
+      assert.equal(errors.length, 1);
+      assert.equal(errors[0].visited, false);
+
+      await act(async () => {
+         store.set("form.visited", true);
+      });
+
+      errors = store.get("errors");
+      assert.equal(errors.length, 1);
+      assert.equal(errors[0].visited, true);
    });
 
    it("disabled flag can be overruled by the field props", async () => {


### PR DESCRIPTION
## Issue

Fixes #1276.

When a `ValidationGroup`'s `visited` binding is initialized to `false` and later set to `true`, the change is not propagated to child fields. If the binding is left uninitialized, it works.

## Root cause

`Field.disableOrValidate` resolved the `visited` flag by coalescing `data.visited` **into itself**:

```js
data.visited = coalesce(parentStrict ? parentVisited : null, data.visited, parentVisited);
```

The four sibling flags (`disabled`, `readOnly`, `viewMode`, `tabOnEnterKey`) each read a separate backing field (`data._disabled`, …) populated in `prepareData`; `visited` had none.

When a field's own bound data is unchanged, `prepareData` is skipped (the memoized selector returns a reference-equal `rawData`), so `instance.data` is the stale object from the previous render. `disableOrValidate`, re-invoked from `explore` on a `parentVisited` change, then reads the already-coalesced stale `data.visited`. Since `coalesce` treats `false` as a defined value, a stale `false` shadows the new `parentVisited` of `true`. With no initialization the stale value is `undefined`, which `coalesce` skips — hence "works without init".

## Fix

Add a `data._visited` backing field in `prepareData` (mirroring `_disabled`, `_readOnly`, `_viewMode`, `_tabOnEnterKey`) and read it in `disableOrValidate`, so the field's own `visited` prop is preserved across renders.

## Test

Added a regression test to `ValidationGroup.spec.tsx`. Verified it fails before the fix (`AssertionError: false == true`) and passes after. Full suite (508 tests) passes.
