### PR TITLE
Add resetRowNumbers grouping flag to Grid

### DIFF
--- a/homedocs/src/examples/tables/GroupRowNumbersExample.tsx
+++ b/homedocs/src/examples/tables/GroupRowNumbersExample.tsx
@@ -1,0 +1,87 @@
+import { createModel } from "cx/data";
+import { Controller, tpl } from "cx/ui";
+import { Grid } from "cx/widgets";
+
+// @model
+interface Person {
+  id: number;
+  fullName: string;
+  continent: string;
+  visits: number;
+}
+
+interface GroupData {
+  $name: string;
+  $level: number;
+  continent: string;
+  fullName: number;
+}
+
+interface PageModel {
+  records: Person[];
+  $record: Person;
+  $group: GroupData;
+}
+
+const m = createModel<PageModel>();
+// @model-end
+
+// @controller
+class PageController extends Controller {
+  onInit() {
+    this.store.set(m.records, [
+      {
+        id: 1,
+        fullName: "Alice Johnson",
+        continent: "North America",
+        visits: 45,
+      },
+      { id: 2, fullName: "Bob Smith", continent: "North America", visits: 32 },
+      {
+        id: 3,
+        fullName: "Henry Taylor",
+        continent: "North America",
+        visits: 25,
+      },
+      { id: 4, fullName: "Carol White", continent: "Europe", visits: 28 },
+      { id: 5, fullName: "David Brown", continent: "Europe", visits: 51 },
+      { id: 6, fullName: "Eva Green", continent: "Europe", visits: 19 },
+      { id: 7, fullName: "Frank Wilson", continent: "Asia", visits: 37 },
+      { id: 8, fullName: "Grace Lee", continent: "Asia", visits: 42 },
+    ]);
+  }
+}
+// @controller-end
+
+// @index
+export default (
+  <Grid
+    controller={PageController}
+    records={m.records}
+    sortField="visits"
+    sortDirection="DESC"
+    grouping={[
+      {
+        key: { continent: m.$record.continent },
+        showCaption: true,
+        resetRowNumbers: true,
+      },
+    ]}
+    columns={[
+      {
+        header: "#",
+        defaultWidth: 50,
+        align: "right",
+        children: <div class="cxe-grid-row-number" />,
+      },
+      {
+        header: "Name",
+        field: "fullName",
+        caption: m.$group.continent,
+      },
+      { header: "Visits", field: "visits", align: "right" },
+    ]}
+    recordAlias={m.$record}
+  />
+);
+// @index-end

--- a/homedocs/src/pages/changelog.mdx
+++ b/homedocs/src/pages/changelog.mdx
@@ -8,6 +8,7 @@ description: Version history and release notes
 
 **Features**
 
+- Added a `resetRowNumbers` flag to `Grid` grouping levels. When set on a grouping level (which must render a caption), the automatic `cxe-grid-row-number` column restarts numbering from 1 at the beginning of each group instead of counting continuously across the grid
 - Added `validateOptionExists` flag to `LookupField`. When enabled and `options` is an array, the field reports a validation error (`invalidOptionText`) if the stored selection is not present in the options list. Useful for surfacing stale ids preserved across sessions ([#1271](https://github.com/codaxy/cxjs/issues/1271))
 
 ---

--- a/homedocs/src/pages/docs/tables/grouping.mdx
+++ b/homedocs/src/pages/docs/tables/grouping.mdx
@@ -14,6 +14,9 @@ import GroupingExampleCode from "../../../examples/tables/GroupingExample.tsx?ra
 import GroupCaptionsExample from "../../../examples/tables/GroupCaptionsExample.tsx";
 import GroupCaptionsExampleCode from "../../../examples/tables/GroupCaptionsExample.tsx?raw";
 
+import GroupRowNumbersExample from "../../../examples/tables/GroupRowNumbersExample.tsx";
+import GroupRowNumbersExampleCode from "../../../examples/tables/GroupRowNumbersExample.tsx?raw";
+
 # Grouping
 
 <OnThisPage collapsed />
@@ -74,14 +77,14 @@ columns={[
 
 ## Aggregate Functions
 
-| Function | Description |
-| -------- | ----------- |
-| `count` | Count non-null values |
-| `sum` | Sum numeric values |
-| `avg` | Average of numeric values |
-| `min` | Minimum value |
-| `max` | Maximum value |
-| `distinct` | Count unique values |
+| Function   | Description               |
+| ---------- | ------------------------- |
+| `count`    | Count non-null values     |
+| `sum`      | Sum numeric values        |
+| `avg`      | Average of numeric values |
+| `min`      | Minimum value             |
+| `max`      | Maximum value             |
+| `distinct` | Count unique values       |
 
 ## Aggregate Alias
 
@@ -105,40 +108,38 @@ Use `showCaption: true` in the grouping configuration to display a caption row f
   <GroupCaptionsExample client:load />
 </CodeExample>
 
-```tsx
-grouping={[{ key: { continent: { bind: "$record.continent" } }, showCaption: true }]}
-columns={[
-  {
-    header: "Name",
-    field: "fullName",
-    aggregate: "count",
-    caption: tpl(m.$group.continent, m.$group.fullName, "{0} ({1} people)"),
-  },
-  // ...
-]}
-```
+## Per-Group Row Numbers
+
+Add a column with the built-in `cxe-grid-row-number` class to display automatic row numbers. By default these count continuously across the whole grid. Set `resetRowNumbers: true` on a grouping level to restart numbering from 1 at the beginning of each group:
+
+<CodeExample code={GroupRowNumbersExampleCode}>
+  <GroupRowNumbersExample client:load />
+</CodeExample>
+
+The counter resets on the group caption row, so the grouping level needs a caption (`showCaption` or `caption`) for the reset to take effect.
 
 ## Group Data
 
 The `$group` object contains:
 
-| Property | Description |
-| -------- | ----------- |
-| `$name` | Group name/label |
-| `$level` | Nesting level (0 for deepest) |
-| `$records` | Records in the group |
-| `$key` | Serialized group key |
-| `[field]` | Aggregate value for each field |
+| Property   | Description                    |
+| ---------- | ------------------------------ |
+| `$name`    | Group name/label               |
+| `$level`   | Nesting level (0 for deepest)  |
+| `$records` | Records in the group           |
+| `$key`     | Serialized group key           |
+| `[field]`  | Aggregate value for each field |
 
 ## Grouping Configuration
 
-| Property | Type | Description |
-| -------- | ---- | ----------- |
-| `key` | `object` | Fields to group by. Empty object groups all records. |
-| `showHeader` | `boolean` | Show group header row. |
-| `showFooter` | `boolean` | Show group footer row. |
-| `showCaption` | `boolean` | Show group caption. |
-| `caption` | `StringProp` | Caption template. |
-| `text` | `StringProp` | Group name template. |
+| Property          | Type         | Description                                                                                                  |
+| ----------------- | ------------ | ------------------------------------------------------------------------------------------------------------ |
+| `key`             | `object`     | Fields to group by. Empty object groups all records.                                                         |
+| `showHeader`      | `boolean`    | Show group header row.                                                                                       |
+| `showFooter`      | `boolean`    | Show group footer row.                                                                                       |
+| `showCaption`     | `boolean`    | Show group caption.                                                                                          |
+| `resetRowNumbers` | `boolean`    | Restart `cxe-grid-row-number` numbering from 1 at the start of each group at this level. Requires a caption. |
+| `caption`         | `StringProp` | Caption template.                                                                                            |
+| `text`            | `StringProp` | Group name template.                                                                                         |
 
 See also: [Dynamic Grouping](/docs/tables/dynamic-grouping), [GroupAdapter](/docs/tables/group-adapter)

--- a/packages/cx/src/widgets/grid/Grid.scss
+++ b/packages/cx/src/widgets/grid/Grid.scss
@@ -184,6 +184,12 @@
       content: counter(cx-row-number);
    }
 
+   // counter-set (not counter-reset) updates the existing row-number counter in place; a
+   // counter-reset here would create a nested counter that the following data rows ignore.
+   .#{$element}#{$name}-group-caption.#{$state}reset-row-numbers {
+      counter-set: cx-row-number 0;
+   }
+
    .#{$element}#{$name}-fixed-header {
       overflow: hidden;
       position: absolute;

--- a/packages/cx/src/widgets/grid/Grid.tsx
+++ b/packages/cx/src/widgets/grid/Grid.tsx
@@ -156,6 +156,11 @@ export interface GridGroupingConfig<T> {
    showCaption?: boolean;
    showFooter?: boolean;
    showHeader?: boolean;
+   /**
+    * Restart automatic row numbers (`cxe-grid-row-number`) from 1 at the beginning of each group
+    * at this grouping level instead of counting continuously across the whole grid. Defaults to `false`.
+    */
+   resetRowNumbers?: boolean;
    caption?: StringProp;
    name?: StringProp;
    text?: StringProp;
@@ -1510,12 +1515,13 @@ export class Grid<T = unknown> extends ContainerBase<GridConfig<T>, GridInstance
    ) {
       let { CSS, baseClass } = this;
       let data = store.getData();
+      let resetRowNumbers = g.resetRowNumbers ? "reset-row-numbers" : null;
       if (g.caption) {
          let caption = g.caption(data);
          return (
             <tbody
                key={`g-${level}-${group.$key}`}
-               className={CSS.element(baseClass, "group-caption", ["level-" + level])}
+               className={CSS.element(baseClass, "group-caption", ["level-" + level, resetRowNumbers])}
                data-group-key={group.$key}
                data-group-element={`group-caption-${level}`}
             >
@@ -1598,7 +1604,7 @@ export class Grid<T = unknown> extends ContainerBase<GridConfig<T>, GridInstance
          return (
             <tbody
                key={"c" + group.$key}
-               className={CSS.element(baseClass, "group-caption", ["level-" + level])}
+               className={CSS.element(baseClass, "group-caption", ["level-" + level, resetRowNumbers])}
                data-group-key={group.$key}
                data-group-element={`group-caption-${level}`}
             >


### PR DESCRIPTION
## Summary

Adds a per-grouping-level `resetRowNumbers` flag to `Grid`. When set on a grouping level, the automatic `cxe-grid-row-number` column restarts numbering from **1** at the beginning of each group instead of counting continuously across the whole grid.

```jsx
grouping={[
   { key: { continent: { bind: "$record.continent" } }, showCaption: true, resetRowNumbers: true },
]}
columns={[
   { header: "#", defaultWidth: 50, children: <div class="cxe-grid-row-number" /> },
   // ...
]}
```

## Implementation

The row-number column is a pure CSS counter: the grid container does `counter-reset: cx-row-number <start>` and each `.cxe-grid-row-number::after` does `counter-increment`. The container reset is **document-global isolation** — without it, two grids on the same page would continue each other's numbering.

The non-obvious part: a `counter-reset` placed on the group **caption** row creates a *nested* counter that is shadowed by the container's reset, so the following data rows ignore it (numbering stays continuous). Using **`counter-set`** on the caption instead updates the existing in-scope counter in place, which correctly resets per group **while keeping the container reset** for cross-grid isolation. Verified in the browser across multiple groups and against a preceding row-numbered grid.

Because the reset rides on the caption row, the grouping level must render a caption (`showCaption` or `caption`) for it to take effect — documented.

## Changes

- `packages/cx/src/widgets/grid/Grid.tsx` — `resetRowNumbers?: boolean` on `GridGroupingConfig`; `renderGroupHeader` adds a `reset-row-numbers` state mod to the group-caption `<tbody>`.
- `packages/cx/src/widgets/grid/Grid.scss` — caption rule `counter-set: cx-row-number 0`.
- `homedocs/` — new "Per-Group Row Numbers" docs section + example, config-table row, and changelog entry.

## Test plan

- [x] Verified live in the docs example: Asia 1‑2, Europe 1‑3, North America 1‑3.
- [x] Confirmed cross-grid isolation still holds (group reset does not leak the counter from a preceding grid).