### PR TITLE
release/26.6.0

### DIFF
--- a/homedocs/src/pages/changelog.mdx
+++ b/homedocs/src/pages/changelog.mdx
@@ -4,7 +4,7 @@ title: Changelog
 description: Version history and release notes
 ---
 
-## Unreleased
+## cx\@26.6.0
 
 **Features**
 

--- a/packages/cx/package.json
+++ b/packages/cx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cx",
-  "version": "26.5.1",
+  "version": "26.6.0",
   "description": "Advanced JavaScript UI framework for admin and dashboard applications with ready to use grid, form and chart components.",
   "exports": {
     "./data": {


### PR DESCRIPTION
Release **cx@26.6.0**.

**Features**

- `Grid` grouping levels: new `resetRowNumbers` flag — restarts the automatic `cxe-grid-row-number` column from 1 at the start of each group (#1299)
- `LookupField`: new `validateOptionExists` flag — reports a validation error when the stored selection is missing from an array `options` list (#1298, [#1271](https://github.com/codaxy/cxjs/issues/1271))

Both changes since 26.5.1 are reflected in the changelog. Bumps `cx` only.