### PR TITLE
Cancel drag-and-drop with the Esc key (#1301)

### DIFF
--- a/packages/cx/src/widgets/drag-drop/DragSource.tsx
+++ b/packages/cx/src/widgets/drag-drop/DragSource.tsx
@@ -2,7 +2,7 @@
 
 import { Widget, VDOM } from "../../ui/Widget";
 import { ContainerBase, ContainerConfig, StyledContainerBase, StyledContainerConfig } from "../../ui/Container";
-import { ddMouseDown, ddDetect, ddMouseUp, initiateDragDrop, isDragHandleEvent } from "./ops";
+import { ddMouseDown, ddDetect, ddMouseUp, initiateDragDrop, isDragHandleEvent, DragEndEvent } from "./ops";
 import { preventFocus } from "../../ui/FocusManager";
 import { parseStyle } from "../../util/parseStyle";
 import { Instance } from "../../ui/Instance";
@@ -30,7 +30,7 @@ export interface DragSourceConfig extends StyledContainerConfig {
 
    onDragStart?: (e: React.MouseEvent | React.TouchEvent, instance: Instance) => any;
 
-   onDragEnd?: (e: React.MouseEvent | React.TouchEvent, instance: Instance) => void;
+   onDragEnd?: (e: DragEndEvent, instance: Instance) => void;
 
    id?: StringProp;
 
@@ -64,7 +64,7 @@ export class DragSource extends StyledContainerBase<DragSourceConfig, DragSource
    declare cloneStyle: any;
    declare draggedStyle: any;
    declare onDragStart?: (e: React.MouseEvent | React.TouchEvent, instance: DragSourceInstance) => any;
-   declare onDragEnd?: (e: React.MouseEvent | React.TouchEvent, instance: DragSourceInstance) => void;
+   declare onDragEnd?: (e: DragEndEvent, instance: DragSourceInstance) => void;
 
    constructor(config?: DragSourceConfig) {
       super(config);

--- a/packages/cx/src/widgets/drag-drop/DropZone.tsx
+++ b/packages/cx/src/widgets/drag-drop/DropZone.tsx
@@ -3,7 +3,7 @@
 import { Widget, VDOM } from "../../ui/Widget";
 import { ContainerBase, ContainerConfig, StyledContainerBase, StyledContainerConfig } from "../../ui/Container";
 import { parseStyle } from "../../util/parseStyle";
-import { registerDropZone, DragDropContext, DragEvent } from "./ops";
+import { registerDropZone, DragDropContext, DragEvent, DragEndEvent } from "./ops";
 import { findScrollableParent } from "../../util/findScrollableParent";
 import { isNumber } from "../../util/isNumber";
 import { getTopLevelBoundingClientRect } from "../../util/getTopLevelBoundingClientRect";
@@ -90,8 +90,8 @@ export interface DropZoneConfig extends StyledContainerConfig {
    /** A callback method invoked when at the beginning of the drag & drop operation. */
    onDragStart?: string | ((event: DragEvent, instance: Instance) => void);
 
-   /** A callback method invoked when at the end of the drag & drop operation. */
-   onDragEnd?: string | ((event: DragEvent, instance: Instance) => void);
+   /** A callback method invoked when at the end of the drag & drop operation. `event.cancelled` is `true` when the operation was cancelled (e.g. via Esc) instead of dropped. */
+   onDragEnd?: string | ((event: DragEndEvent, instance: Instance) => void);
 
    /** Match height of the item being dragged */
    matchHeight?: boolean;
@@ -126,7 +126,7 @@ export class DropZone extends StyledContainerBase<DropZoneConfig, DropZoneInstan
    declare onDragEnter?: string | ((event?: DragEvent, instance?: Instance) => void);
    declare onDragLeave?: string | ((event?: DragEvent, instance?: Instance) => void);
    declare onDragStart?: string | ((event?: DragEvent, instance?: Instance) => void);
-   declare onDragEnd?: string | ((event?: DragEvent, instance?: Instance) => void);
+   declare onDragEnd?: string | ((event?: DragEndEvent, instance?: Instance) => void);
 
    constructor(config?: DropZoneConfig) {
       super(config);
@@ -342,7 +342,7 @@ class DropZoneComponent extends VDOM.Component<DropZoneComponentProps, DropZoneC
       if (this.state.state == "over" && widget.onDrop) instance.invoke("onDrop", e, instance);
    }
 
-   onDragEnd(e: DragEvent) {
+   onDragEnd(e: DragEndEvent) {
       this.setState({
          state: false,
          style: null,

--- a/packages/cx/src/widgets/drag-drop/ops.tsx
+++ b/packages/cx/src/widgets/drag-drop/ops.tsx
@@ -21,6 +21,18 @@ export interface DragEvent {
    result?: any;
 }
 
+export interface DragEndEvent {
+   type: "dragend";
+   /** The triggering pointer event, or `null` when the operation was cancelled via the keyboard. */
+   event: DragEvent["event"] | null;
+   /** Cursor position, or `null` when the operation was cancelled via the keyboard. */
+   cursor: CursorPosition | null;
+   source: DragEvent["source"];
+   /** `true` when the operation was cancelled (e.g. by pressing Esc) instead of dropped. */
+   cancelled: boolean;
+   result?: any;
+}
+
 export interface DragDropOptions {
    sourceEl?: Element | null;
    clone?: any;
@@ -38,7 +50,7 @@ export interface IDropZone {
    onDragStart?: DragEventHandler;
    onDragAway?: DragEventHandler;
    onDragNear?: DragEventHandler;
-   onDragEnd?: DragEventHandler;
+   onDragEnd?: (e: DragEndEvent) => void;
    onDragMeasure?: (
       e: DragEvent,
       operation: DragDropOperationContext,
@@ -62,7 +74,6 @@ import { getTopLevelBoundingClientRect } from "../../util/getTopLevelBoundingCli
 import { VDOM } from "../../ui/VDOM";
 import { Container } from "../../ui/Container";
 import { Console } from "../../util";
-import { WidgetConfig } from "../../ui";
 
 interface Puppet {
    deltaX: number;
@@ -70,7 +81,7 @@ interface Puppet {
    el: HTMLDivElement;
    clone: any;
    source: any;
-   onDragEnd?: (e?: DragEvent) => void;
+   onDragEnd?: (e?: DragEndEvent) => void;
    stop?: () => void;
 }
 
@@ -82,6 +93,7 @@ let puppet: Puppet | null = null;
 let scrollTimer: number | null = null;
 let vscrollParent: Element | null = null;
 let hscrollParent: Element | null = null;
+let releaseCapture: (() => void) | null = null;
 
 export function registerDropZone(dropZone: IDropZone): UnregisterFunction {
    dropZones.push(dropZone);
@@ -94,7 +106,7 @@ export function registerDropZone(dropZone: IDropZone): UnregisterFunction {
 export function initiateDragDrop(
    e: MouseEvent | TouchEvent | React.MouseEvent | React.TouchEvent,
    options: DragDropOptions = {},
-   onDragEnd?: (e?: DragEvent) => void,
+   onDragEnd?: (e?: DragEndEvent) => void,
 ): void {
    if (puppet) {
       //last operation didn't finish properly
@@ -187,7 +199,16 @@ export function initiateDragDrop(
 
    notifyDragMove(e, null);
 
-   captureMouseOrTouch(e, notifyDragMove, notifyDragDrop);
+   releaseCapture = captureMouseOrTouch(e, notifyDragMove, notifyDragDrop);
+   document.addEventListener("keydown", onDragKeyDown, true);
+}
+
+function onDragKeyDown(e: KeyboardEvent): void {
+   if (!puppet || e.key !== "Escape") return;
+   //cancel the operation without dropping; there is no pointer event to report
+   e.preventDefault();
+   e.stopPropagation();
+   notifyDragDrop(null, true);
 }
 
 function notifyDragMove(e: React.MouseEvent | React.TouchEvent | MouseEvent | TouchEvent, _captureData: any): void {
@@ -321,29 +342,50 @@ function clearScrollTimer() {
    }
 }
 
-function notifyDragDrop(e: MouseEvent | TouchEvent | React.MouseEvent | React.TouchEvent): void {
+function notifyDragDrop(
+   e: MouseEvent | TouchEvent | React.MouseEvent | React.TouchEvent | null,
+   cancelled: boolean = false,
+): void {
+   if (!puppet) return;
+
    clearScrollTimer();
+   document.removeEventListener("keydown", onDragKeyDown, true);
 
-   let event = getDragEvent(e, "dragdrop");
+   if (puppet.stop) puppet.stop();
 
-   if (puppet!.stop) puppet!.stop();
+   //a keyboard cancellation has no pointer event, so the drop and away notifications are skipped
+   let dropEvent = !cancelled && e ? getDragEvent(e, "dragdrop") : null;
 
-   if (activeZone && activeZone.onDrop) event.result = activeZone.onDrop(event);
+   let result: any;
+   if (dropEvent && activeZone && activeZone.onDrop) result = activeZone.onDrop(dropEvent);
+
+   let endEvent: DragEndEvent = {
+      type: "dragend",
+      event: e,
+      cursor: e ? getCursorPos(e) : null,
+      source: puppet.source,
+      cancelled,
+      result,
+   };
 
    dropZones.forEach((zone) => {
-      if (nearZones != null && zone.onDragAway && nearZones.has(zone)) zone.onDragAway(event);
+      if (dropEvent && nearZones != null && zone.onDragAway && nearZones.has(zone)) zone.onDragAway(dropEvent);
 
       if (!dragStartedZones!.has(zone)) return;
 
-      if (zone.onDragEnd) zone.onDragEnd(event);
+      if (zone.onDragEnd) zone.onDragEnd(endEvent);
    });
 
-   if (puppet!.onDragEnd) puppet!.onDragEnd(event);
+   if (puppet.onDragEnd) puppet.onDragEnd(endEvent);
+
+   //tear down the mouse/touch capture when cancelling; on a normal drop the capture ends itself
+   if (cancelled && releaseCapture) releaseCapture();
 
    nearZones = null;
    activeZone = null;
    puppet = null;
    dragStartedZones = null;
+   releaseCapture = null;
 }
 
 function getDragEvent(

--- a/packages/cx/src/widgets/grid/Grid.tsx
+++ b/packages/cx/src/widgets/grid/Grid.tsx
@@ -63,6 +63,7 @@ import {
    ddMouseDown,
    DragDropOperationContext,
    DragEvent,
+   DragEndEvent,
    initiateDragDrop,
    registerDropZone,
 } from "../drag-drop/ops";
@@ -400,7 +401,7 @@ export interface GridConfig<T = any> extends StyledContainerConfig {
    onDrop?: string | ((e: GridDragEvent<T>, instance: Instance) => void);
    onDropTest?: string | ((e: DragEvent, instance: Instance) => boolean);
    onDragStart?: string | ((e: DragEvent, instance: Instance) => void);
-   onDragEnd?: string | ((e: DragEvent, instance: Instance) => void);
+   onDragEnd?: string | ((e: DragEndEvent, instance: Instance) => void);
    onDragOver?: string | ((e: GridDragEvent<T>, instance: Instance) => void | boolean);
 
    onRowDropTest?: string | ((e: DragEvent, instance: Instance) => boolean);
@@ -2871,7 +2872,7 @@ class GridComponent extends VDOM.Component<GridComponentProps, GridComponentStat
       return (grid || row || column) && { grid, row, column };
    }
 
-   onDragEnd(e: DragEvent) {
+   onDragEnd(e: DragEndEvent) {
       this.setState({
          dropTarget: null,
          dropInsertionIndex: null,

--- a/packages/cx/src/widgets/overlay/captureMouse.ts
+++ b/packages/cx/src/widgets/overlay/captureMouse.ts
@@ -31,7 +31,7 @@ interface CaptureMouseOptions {
 export function captureMouse2(
    e: React.MouseEvent | React.TouchEvent | MouseEvent | TouchEvent,
    options: CaptureMouseOptions,
-): void {
+): () => void {
    let surface = document.createElement("div");
    surface.className = "cxb-mousecapture";
    surface.style.cursor = options.cursor || getComputedStyle(e.currentTarget as Element).cursor;
@@ -66,6 +66,8 @@ export function captureMouse2(
    }
 
    e.stopPropagation();
+
+   return tear;
 
    function move(e: Event) {
       if (!active) {
@@ -110,7 +112,7 @@ export function captureMouse2(
 export function captureMouseOrTouch2(
    e: React.MouseEvent | React.TouchEvent | MouseEvent | TouchEvent,
    options: CaptureMouseOptions,
-): void {
+): () => void {
    if (e.type.indexOf("touch") == 0) {
       let el = e.currentTarget as HTMLElement;
 
@@ -136,7 +138,12 @@ export function captureMouseOrTouch2(
       el.addEventListener("touchend", end);
 
       e.stopPropagation();
-   } else captureMouse2(e, options);
+
+      return () => {
+         el.removeEventListener("touchmove", move);
+         el.removeEventListener("touchend", end);
+      };
+   } else return captureMouse2(e, options);
 }
 
 /**
@@ -153,8 +160,8 @@ export function captureMouse(
    onMouseUp?: (e: MouseEvent | TouchEvent, captureData?: any) => void,
    captureData?: any,
    cursor?: string,
-): void {
-   captureMouse2(e, {
+): () => void {
+   return captureMouse2(e, {
       onMouseMove,
       onMouseUp,
       captureData,
@@ -176,8 +183,8 @@ export function captureMouseOrTouch(
    onMouseUp?: (e: MouseEvent, captureData?: any) => void,
    captureData?: any,
    cursor?: string,
-): void {
-   captureMouseOrTouch2(e, { onMouseMove, onMouseUp, captureData, cursor });
+): () => void {
+   return captureMouseOrTouch2(e, { onMouseMove, onMouseUp, captureData, cursor });
 }
 
 /**


### PR DESCRIPTION
Closes #1301.

## Summary

Pressing **Esc** during a drag-and-drop operation now cancels it: nothing is dropped, drop zones reset their state, the drag clone is removed, and the mouse/touch capture is released.

## Changes

**`drag-drop/ops.tsx`**
- A global `keydown` listener is registered for the duration of a drag. On **Escape** it runs the end sequence via `notifyDragDrop(null, /*cancelled*/ true)` — skipping `onDrop` — and tears down the capture.
- Introduces a dedicated **`DragEndEvent`** with a `cancelled` flag, so `onDragEnd` handlers can distinguish a cancel from a drop (and still read `result`). On a keyboard cancel there is no pointer event, so its `event` and `cursor` are `null`.

**`overlay/captureMouse.ts`**
- The capture helpers (`captureMouse`/`captureMouseOrTouch` and the `*2` variants) now return a teardown function so the capture can be released programmatically. Additive — existing callers ignore the return value.

**`DropZone` / `DragSource` / `Grid`**
- `onDragEnd` now receives a `DragEndEvent`. `onDrop` and `onDragAway` continue to use `DragEvent` (they only fire on a real pointer drop).

## Behavior notes

- The normal drop path is unchanged: `onDrop` / `onDragAway` / `onDragEnd` fire as before with `cancelled: false`.
- On cancel, `onDrop` and the end-of-drag `onDragAway` do not fire (no pointer event); `onDragEnd` fires for every started zone, which fully resets zone state, with `cancelled: true`.

## Tests

`yarn check-types` clean, `yarn test` 525 passing. Drag-and-drop is event/DOM-driven with no unit coverage, so this was verified by type-checking and manual reasoning through both the drop and cancel paths.

## Notes

- Changelog intentionally omitted — to be added with the release.