### PR TITLE
Security: Predictable OAuth state parameter using Math.random() enables CSRF on OAuth callback

### DIFF
--- a/legacy/fiddle/app/routes/login/PickAuthProviderPage.js
+++ b/legacy/fiddle/app/routes/login/PickAuthProviderPage.js
@@ -6,7 +6,7 @@ class PickController extends Controller {
    init() {
       super.init();
 
-      var state = String(Math.random() * 1000000);
+      var state = Array.from(crypto.getRandomValues(new Uint8Array(16)), b => b.toString(16).padStart(2, '0')).join('');
 
       this.store.set('login.providers', Object.keys(config.login).map(id=> {
          var c = config.login[id];


### PR DESCRIPTION
## Problem

The OAuth `state` parameter is generated using `Math.random()`, which is not cryptographically secure and produces predictable values. The `state` parameter is the primary CSRF protection in the OAuth authorization code flow. An attacker who can predict the state value can initiate their own OAuth authorization request and trick a victim into completing it, potentially linking the attacker's third-party account to the victim's session (login CSRF / account takeover). This is especially dangerous because the state is never validated server-side in the visible code — it's only generated and embedded into the authorization URL.


**Severity**: `high`
**File**: `legacy/fiddle/app/routes/login/PickAuthProviderPage.js`

## Solution

Replace Math.random() with crypto.getRandomValues() for the state parameter:


## Changes

- `legacy/fiddle/app/routes/login/PickAuthProviderPage.js` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
