### PR TITLE
fix(TreeNode): add missing arrowIcon to TreeNodeConfig

### DIFF
--- a/packages/cx/src/widgets/grid/TreeNode.tsx
+++ b/packages/cx/src/widgets/grid/TreeNode.tsx
@@ -41,6 +41,9 @@ export interface TreeNodeConfig extends StyledContainerConfig {
   /** Icon for folder. */
   folderIcon?: StringProp;
 
+  /** Icon used for the expand/collapse arrow. Defaults to `drop-down`. */
+  arrowIcon?: StringProp;
+
   /** Set to `true` to hide the icon. */
   hideIcon?: boolean;
 


### PR DESCRIPTION
The TreeNode widget reads `arrowIcon` (defaulting to `drop-down`) and renders it as the expand/collapse glyph, but the prop was absent from `TreeNodeConfig`, so setting it from JSX raised a type error. Add it alongside the other icon props.